### PR TITLE
Improvements to Windows installer

### DIFF
--- a/install_windows.R
+++ b/install_windows.R
@@ -39,7 +39,7 @@ if (! haspkg("msa")) {
   cat("### Installing Bioconductor and MSA\n")
   cat("\n")
   source("https://bioconductor.org/biocLite.R")
-  biocLite("msa")
+  biocLite("msa", suppressUpdates = TRUE)
 }
 
 cat("\n")

--- a/install_windows.R
+++ b/install_windows.R
@@ -21,14 +21,20 @@ if (! any(file.access(.libPaths(), 2) == 0)) {
   .libPaths(dp)
 }
 
-if (! require("devtools", character.only = TRUE, quietly = TRUE)) {
+haspkg <- function(pkgname) {
+  suppressMessages(suppressWarnings(
+    require(pkgname, character.only = TRUE, quietly = TRUE)
+  ))
+}
+
+if (! haspkg("devtools")) {
   cat("\n")
   cat("### Installing devtools\n")
   cat("\n")
   install.packages("devtools", repos = "https://cloud.r-project.org")
 }
 
-if (! suppressMessages(require("msa", character.only = TRUE, quietly = TRUE))) {
+if (! haspkg("msa")) {
   cat("\n")
   cat("### Installing Bioconductor and MSA\n")
   cat("\n")

--- a/install_windows.R
+++ b/install_windows.R
@@ -21,38 +21,25 @@ if (! any(file.access(.libPaths(), 2) == 0)) {
   .libPaths(dp)
 }
 
-cat("\n")
-cat("### Installing devtools\n")
-cat("\n")
-install.packages("devtools", repos = "https://cloud.r-project.org")
+if (! require("devtools", character.only = TRUE, quietly = TRUE)) {
+  cat("\n")
+  cat("### Installing devtools\n")
+  cat("\n")
+  install.packages("devtools", repos = "https://cloud.r-project.org")
+}
 
-cat("\n")
-cat("### Installing Bioconductor and MSA\n")
-cat("\n")
-source("https://bioconductor.org/biocLite.R")
-biocLite("msa")
-
-cat("\n")
-cat("### Installing dependencies\n")
-cat("\n")
-devtools::install_deps(path, dependencies = TRUE)
-
-cat("\n")
-cat("### Testing CHIIMP\n")
-cat("\n")
-status <- sum(as.data.frame(devtools::test(path))$failed)
-if (status == 1) {
+if (! suppressMessages(require("msa", character.only = TRUE, quietly = TRUE))) {
   cat("\n")
+  cat("### Installing Bioconductor and MSA\n")
   cat("\n")
-  cat("    Warning: Tests indicated failures.\n")
-  cat("\n")
-  cat("\n")
+  source("https://bioconductor.org/biocLite.R")
+  biocLite("msa")
 }
 
 cat("\n")
 cat("### Installing CHIIMP\n")
 cat("\n")
-devtools::install(path)
+devtools::install(path, upgrade = "never")
 
 shortcut_path <- file.path(UPROF, "Desktop", "CHIIMP.lnk")
 chiimp_path <- system.file("bin", "chiimp.cmd", package = "chiimp")

--- a/install_windows.cmd
+++ b/install_windows.cmd
@@ -17,3 +17,4 @@ set pkgdir=%~dp0
 
 REM  Run bulk of the install within R.
 "%rscript%" --vanilla "%pkgdir%\install_windows.R"
+pause


### PR DESCRIPTION
This fixes #29 and simplifies the install process on Windows, particularly for reinstall where dependencies are already met.

 * Only attempt install of devtools and msa if they are not currently installed
 * Disable auto-update of dependencies during devtools- and bioconductor-based package installs
 * Remove redundant test and dependency-install steps
 * Add a `pause` statement at the end to hold the cmd.exe window open
