### PR TITLE
Configure Travis and Demos for Mac OS X Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,12 @@ r:
   - oldrel
   - release
   - devel
+# Mac OS R devel build URL is out of date, currently.
+# https://travis-ci.community/t/672
+matrix:
+  exclude:
+    - r: devel
+      os: osx
 cache: packages
 script:
   - R CMD build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# https://docs.travis-ci.com/user/multi-os/
+os:
+  - linux
+  - osx
 # https://docs.travis-ci.com/user/languages/r
 language: r
 bioc_packages: msa

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ r:
   - oldrel
   - release
   - devel
-  - bioc-devel
 cache: packages
 script:
   - R CMD build .

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# chiimp dev
+
+ * Added support for demo scripts and integration testing in Mac OS ([#32]).
+
+[#32]: https://github.com/ShawHahnLab/chiimp/pull/32
+
 # chiimp 0.2.3
 
  * Fixed package checks and testing on latest R development releases ([#27]).

--- a/inst/bin/demo.sh
+++ b/inst/bin/demo.sh
@@ -3,10 +3,12 @@
 # Wrapper script to set up and execute a demo, using the "chiimp" executable
 # R script and the test data.
 
-dir=$(readlink -f $(dirname $BASH_SOURCE))
+cd "$(dirname $BASH_SOURCE)"
+dir=$(pwd -P)
 scratch=$(mktemp -d)
-R --vanilla -q -e "devtools::load_all('.', quiet=T); test_data\$write_seqs(test_data\$seqs, '$scratch/str-dataset', 'Replicate1-Sample%s-%s.fasta')"
+R --vanilla -q -e "devtools::load_all('..', quiet=T); test_data\$write_seqs(test_data\$seqs, '$scratch/str-dataset', 'Replicate1-Sample%s-%s.fasta')" > /dev/null
 cp "$dir/../example_locus_attrs.csv" "$scratch/locus_attrs.csv"
 cp "$dir/../example_config.yml" "$scratch/config.yml"
 cd "$scratch"
 "$dir/chiimp" "config.yml"
+echo "Demo files and output stored in $(pwd -P)"

--- a/inst/bin/demo_empty.sh
+++ b/inst/bin/demo_empty.sh
@@ -5,7 +5,8 @@
 #
 # Special case: all empty input files
 
-dir=$(readlink -f $(dirname $BASH_SOURCE))
+cd "$(dirname $BASH_SOURCE)"
+dir=$(pwd -P)
 scratch=$(mktemp -d)
 mkdir -p "$scratch/str-dataset"
 for samp in {1..3}; do
@@ -17,3 +18,4 @@ cp "$dir/../example_locus_attrs.csv" "$scratch/locus_attrs.csv"
 cp "$dir/../example_config.yml" "$scratch/config.yml"
 cd "$scratch"
 "$dir/chiimp" "config.yml"
+echo "Demo files and output stored in $(pwd -P)"


### PR DESCRIPTION
This changes the Travis configuration and demo scripts to work on OS X.  The R package and desktop shortcut already did, but this will enable automated testing as on Linux.

 * Switches to `pwd -P` rather than `readlink -f` for determining canonical paths in the demo scripts
 * Enables `osx` in the Travis configuration but excludes the devel R build which has [known problems](https://travis-ci.community/t/r-devel-el-capitan-signed-pkg-fails-to-download-when-testing-on-r-devel/672) for Travis' osx