### PR TITLE
Configurable threshold for stutter and artifact matching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # chiimp dev
 
+ * Made read count ratio thresholds for PCR stutter and artifact sequence
+   flagging customizable ([#46]).
  * Added drag-and-drop usage message when desktop icon is opened directly
    ([#44]).
  * Added `load_csv` and `save_csv` functions to centralize loading and saving
@@ -7,6 +9,7 @@
  * Reorganized installer and wrapper scripts ([#38]).
  * Added support for demo scripts and integration testing in Mac OS ([#32]).
 
+[#46]: https://github.com/ShawHahnLab/chiimp/pull/46
 [#44]: https://github.com/ShawHahnLab/chiimp/pull/44
 [#43]: https://github.com/ShawHahnLab/chiimp/pull/43
 [#38]: https://github.com/ShawHahnLab/chiimp/pull/38

--- a/R/analyze_dataset.R
+++ b/R/analyze_dataset.R
@@ -20,6 +20,11 @@
 #'   \code{\link{load_locus_attrs}}.
 #' @param nrepeats number of repeats of each locus' motif to require for a
 #'   match (see \code{\link{analyze_seqs}}).
+#' @param stutter.count.ratio_max highest ratio of read counts for second most
+#'   frequent sequence to the most frequence where the second will be
+#'   considered stutter (see \code{\link{analyze_seqs}}).
+#' @param artifact.count.ratio_max as for \code{stutter.count.ratio_max} but for
+#'   non-stutter artifact sequences.
 #' @param ncores integer number of CPU cores to use in parallel for sample
 #'   analysis.  Defaults to one less than half the number of detected cores with
 #'   a minimum of 1.  If 1, the function will run without using the
@@ -44,16 +49,19 @@
 #'   per-sample data frames.
 #'
 #' @export
-analyze_dataset <- function(dataset,
-                            locus_attrs,
-                            nrepeats,
-                            ncores = 0,
-                            analysis_opts,
-                            summary_opts,
-                            analysis_function=analyze_sample,
-                            summary_function=summarize_sample,
-                            known_alleles=NULL,
-                            name_args=list()) {
+analyze_dataset <- function(
+  dataset,
+  locus_attrs,
+  nrepeats,
+  stutter.count.ratio_max = config.defaults$seq_analysis$stutter.count.ratio_max,
+  artifact.count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max,
+  ncores = 0,
+  analysis_opts,
+  summary_opts,
+  analysis_function=analyze_sample,
+  summary_function=summarize_sample,
+  known_alleles=NULL,
+  name_args=list()) {
   if (! all(dataset$Locus %in% locus_attrs$Locus)) {
     rogue_loci <- unique(dataset$Locus[! dataset$Locus %in% locus_attrs$Locus])
     msg <- paste("ERROR: Locus names in dataset not in attributes table:",
@@ -63,9 +71,11 @@ analyze_dataset <- function(dataset,
   if (ncores == 0) {
     ncores <- max(1, as.integer(parallel::detectCores() / 2) - 1)
   }
-  analyze.file <- function(fp, locus_attrs, nrepeats) {
+  analyze.file <- function(fp, locus_attrs, nrepeats,
+                           stutter.count.ratio_max, artifact.count.ratio_max) {
     seqs <- load_seqs(fp)
-    analyze_seqs(seqs, locus_attrs, nrepeats)
+    analyze_seqs(seqs, locus_attrs, nrepeats,
+                 stutter.count.ratio_max, artifact.count.ratio_max)
   }
   analyze.entry <- function(entry, analysis_opts, summary_opts,
                             analysis_function, summary_function,
@@ -114,7 +124,9 @@ analyze_dataset <- function(dataset,
       fps <- unique(dataset$Filename)
       analyzed_files <- parallel::parLapply(cluster, fps, analyze.file,
                                             locus_attrs = locus_attrs,
-                                            nrepeats = nrepeats)
+                                            nrepeats = nrepeats,
+                                            stutter.count.ratio_max,
+                                            artifact.count.ratio_max)
       names(analyzed_files) <- fps
       raw.results <- parallel::parApply(cluster, dataset, 1, analyze.entry,
                                         analysis_opts = analysis_opts,
@@ -130,7 +142,9 @@ analyze_dataset <- function(dataset,
     fps <- unique(dataset$Filename)
     analyzed_files <- lapply(fps, analyze.file,
                              locus_attrs = locus_attrs,
-                             nrepeats = nrepeats)
+                             nrepeats = nrepeats,
+                             stutter.count.ratio_max,
+                             artifact.count.ratio_max)
     names(analyzed_files) <- fps
     raw.results <- apply(dataset, 1, analyze.entry,
                          analysis_opts = analysis_opts,

--- a/R/chiimp.R
+++ b/R/chiimp.R
@@ -191,6 +191,8 @@ full_analysis <- function(config, dataset=NULL) {
     allele.names <- load_allele_names(cfg$fp_allele_names)
   results <- analyze_dataset(dataset, locus_attrs,
                              nrepeats = cfg$seq_analysis$nrepeats,
+                             stutter.count.ratio_max = cfg$seq_analysis$stutter.count.ratio_max,
+                             artifact.count.ratio_max = cfg$seq_analysis$artifact.count.ratio_max,
                              ncores = cfg$dataset_analysis$ncores,
                              analysis_opts = cfg$sample_analysis_opts,
                              summary_opts = cfg$sample_summary_opts,

--- a/R/configuration.R
+++ b/R/configuration.R
@@ -59,7 +59,11 @@ config.defaults <- list(
     name_args = list(hash_len = 6)
   ),
   ## Sample genotyping settings
-  seq_analysis = list(nrepeats = 3),
+  seq_analysis = list(
+    nrepeats = 3,
+    stutter.count.ratio_max = 1 / 3,
+    artifact.count.ratio_max = 1 / 3
+  ),
   sample_analysis_func = "analyze_sample",
   sample_analysis_opts = list(fraction.min = 0.05),
   sample_summary_func = "summarize_sample",

--- a/man/analyze_dataset.Rd
+++ b/man/analyze_dataset.Rd
@@ -4,8 +4,11 @@
 \alias{analyze_dataset}
 \title{Analyze all samples in a dataset}
 \usage{
-analyze_dataset(dataset, locus_attrs, nrepeats, ncores = 0, analysis_opts,
-  summary_opts, analysis_function = analyze_sample,
+analyze_dataset(dataset, locus_attrs, nrepeats,
+  stutter.count.ratio_max = config.defaults$seq_analysis$stutter.count.ratio_max,
+  artifact.count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max,
+  ncores = 0, analysis_opts, summary_opts,
+  analysis_function = analyze_sample,
   summary_function = summarize_sample, known_alleles = NULL,
   name_args = list())
 }
@@ -18,6 +21,13 @@ analyze_dataset(dataset, locus_attrs, nrepeats, ncores = 0, analysis_opts,
 
 \item{nrepeats}{number of repeats of each locus' motif to require for a
 match (see \code{\link{analyze_seqs}}).}
+
+\item{stutter.count.ratio_max}{highest ratio of read counts for second most
+frequent sequence to the most frequence where the second will be
+considered stutter (see \code{\link{analyze_seqs}}).}
+
+\item{artifact.count.ratio_max}{as for \code{stutter.count.ratio_max} but for
+non-stutter artifact sequences.}
 
 \item{ncores}{integer number of CPU cores to use in parallel for sample
 analysis.  Defaults to one less than half the number of detected cores with

--- a/man/analyze_seqs.Rd
+++ b/man/analyze_seqs.Rd
@@ -4,7 +4,9 @@
 \alias{analyze_seqs}
 \title{Analyze a set of STR sequences}
 \usage{
-analyze_seqs(seqs, locus_attrs, nrepeats)
+analyze_seqs(seqs, locus_attrs, nrepeats,
+  stutter.count.ratio_max = config.defaults$seq_analysis$stutter.count.ratio_max,
+  artifact.count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max)
 }
 \arguments{
 \item{seqs}{character vector containing sequences.}
@@ -13,6 +15,13 @@ analyze_seqs(seqs, locus_attrs, nrepeats)
 
 \item{nrepeats}{number of repeats of each locus' motif to require for a
 match.}
+
+\item{stutter.count.ratio_max}{highest ratio of read counts for second most
+frequent sequence to the most frequence where the second will be
+considered stutter.}
+
+\item{artifact.count.ratio_max}{as for \code{stutter.count.ratio_max} but for
+non-stutter artifact sequences.}
 }
 \value{
 data frame of dereplicated sequences with added annotations.

--- a/man/find_artifact.Rd
+++ b/man/find_artifact.Rd
@@ -4,7 +4,8 @@
 \alias{find_artifact}
 \title{Check for non-stutter PCR artifacts between sequences}
 \usage{
-find_artifact(sample.data, locus_attrs, count.ratio_max = 1/3)
+find_artifact(sample.data, locus_attrs,
+  count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max)
 }
 \arguments{
 \item{sample.data}{data frame of processed sample data.}

--- a/man/find_stutter.Rd
+++ b/man/find_stutter.Rd
@@ -4,7 +4,8 @@
 \alias{find_stutter}
 \title{Check for PCR stutter between sequences}
 \usage{
-find_stutter(sample.data, locus_attrs, count.ratio_max = 1/3)
+find_stutter(sample.data, locus_attrs,
+  count.ratio_max = config.defaults$seq_analysis$stutter.count.ratio_max)
 }
 \arguments{
 \item{sample.data}{data frame of processed sample data.}

--- a/tests/testthat/test_analyze_seqs.R
+++ b/tests/testthat/test_analyze_seqs.R
@@ -79,8 +79,27 @@ with(test_data, {
     chunk <- subset(seq_data, !is.na(Stutter))
     expect_equal(chunk$Count, c(279, 114, 2, 2, 2))
     expect_equal(chunk$Stutter, c(1, 2, 2, 2, 2))
-    # TODO add expectation for high-count case that should not be marked as
-    # stutter
+  })
+
+  test_that("analyze_seqs does not mark high-count entries as stutter", {
+    # replace a few high-count entries with one that was considered stutter
+    # in the above test.  Now none of those top sequences should be considered
+    # stutter.
+    s <- seqs1$A
+    s[nchar(s) %in% c(158, 54)] <- s[nchar(s) == 190][1]
+    seq_data <- analyze_seqs(s, locus_attrs, 3)
+    chunk <- subset(seq_data, !is.na(Stutter))
+    expect_equal(chunk$Count, c(2, 2, 2))
+    expect_equal(chunk$Stutter, c(2, 2, 2))
+  })
+
+  test_that("analyze_seqs works with varied threshold for stutter counts", {
+    s <- seqs1$A
+    s[nchar(s) %in% c(158, 54)] <- s[nchar(s) == 190][1]
+    seq_data <- analyze_seqs(s, locus_attrs, 3, stutter.count.ratio_max = 1/2)
+    chunk <- subset(seq_data, !is.na(Stutter))
+    expect_equal(chunk$Count, c(443, 2, 2, 2, 1, 1))
+    expect_equal(chunk$Stutter, c(2, 2, 2, 2, 4, 4))
   })
 
   test_that("analyze_seqs marks artifact entries", {


### PR DESCRIPTION
This replaces the previously-hardcoded read count ratios for find_stutter and find_artifact with values in the configuration list/file.  Fixes #41.