### PR TITLE
Enable support for reverse primers in locus-matching

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Encoding: UTF-8
 LazyData: true
 Imports:
   argparser (>= 0.4),
+  Biostrings (>= 2.38.4),
   dnaplotr (>= 0.1),
   dnar (>= 0.1),
   devtools (>= 1.13.5),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # chiimp dev
 
+ * Added support for use of reverse primers in locus-matching ([#47]).
  * Made read count ratio thresholds for PCR stutter and artifact sequence
    flagging customizable ([#46]).
  * Added drag-and-drop usage message when desktop icon is opened directly
@@ -9,6 +10,7 @@
  * Reorganized installer and wrapper scripts ([#38]).
  * Added support for demo scripts and integration testing in Mac OS ([#32]).
 
+[#47]: https://github.com/ShawHahnLab/chiimp/pull/47
 [#46]: https://github.com/ShawHahnLab/chiimp/pull/46
 [#44]: https://github.com/ShawHahnLab/chiimp/pull/44
 [#43]: https://github.com/ShawHahnLab/chiimp/pull/43

--- a/R/analyze_dataset.R
+++ b/R/analyze_dataset.R
@@ -25,6 +25,8 @@
 #'   considered stutter (see \code{\link{analyze_seqs}}).
 #' @param artifact.count.ratio_max as for \code{stutter.count.ratio_max} but for
 #'   non-stutter artifact sequences.
+#' @param use_reverse_primers consider the ReversePrimer column from the locus
+#'   attributes for locus-matching?
 #' @param reverse_primer_r1 Is each reverse primer given in its orientation on
 #'   the forward read?  (See \code{\link{analyze_seqs}})
 #' @param ncores integer number of CPU cores to use in parallel for sample
@@ -59,6 +61,8 @@ analyze_dataset <- function(
     stutter.count.ratio_max,
   artifact.count.ratio_max = config.defaults$seq_analysis$
     artifact.count.ratio_max,
+  use_reverse_primers = config.defaults$seq_analysis$
+    use_reverse_primers,
   reverse_primer_r1 = config.defaults$seq_analysis$
     reverse_primer_r1,
   ncores = 0,
@@ -79,10 +83,12 @@ analyze_dataset <- function(
   }
   analyze.file <- function(fp, locus_attrs, nrepeats,
                            stutter.count.ratio_max, artifact.count.ratio_max,
+                           use_reverse_primers,
                            reverse_primer_r1) {
     seqs <- load_seqs(fp)
     analyze_seqs(seqs, locus_attrs, nrepeats,
                  stutter.count.ratio_max, artifact.count.ratio_max,
+                 use_reverse_primers,
                  reverse_primer_r1)
   }
   analyze.entry <- function(entry, analysis_opts, summary_opts,
@@ -135,6 +141,7 @@ analyze_dataset <- function(
                                             nrepeats = nrepeats,
                                             stutter.count.ratio_max,
                                             artifact.count.ratio_max,
+                                            use_reverse_primers,
                                             reverse_primer_r1)
       names(analyzed_files) <- fps
       raw.results <- parallel::parApply(cluster, dataset, 1, analyze.entry,
@@ -154,6 +161,7 @@ analyze_dataset <- function(
                              nrepeats = nrepeats,
                              stutter.count.ratio_max,
                              artifact.count.ratio_max,
+                             use_reverse_primers,
                              reverse_primer_r1)
     names(analyzed_files) <- fps
     raw.results <- apply(dataset, 1, analyze.entry,

--- a/R/analyze_dataset.R
+++ b/R/analyze_dataset.R
@@ -25,6 +25,8 @@
 #'   considered stutter (see \code{\link{analyze_seqs}}).
 #' @param artifact.count.ratio_max as for \code{stutter.count.ratio_max} but for
 #'   non-stutter artifact sequences.
+#' @param reverse_primer_r1 Is each reverse primer given in its orientation on
+#'   the forward read?  (See \code{\link{analyze_seqs}})
 #' @param ncores integer number of CPU cores to use in parallel for sample
 #'   analysis.  Defaults to one less than half the number of detected cores with
 #'   a minimum of 1.  If 1, the function will run without using the
@@ -53,8 +55,12 @@ analyze_dataset <- function(
   dataset,
   locus_attrs,
   nrepeats,
-  stutter.count.ratio_max = config.defaults$seq_analysis$stutter.count.ratio_max,
-  artifact.count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max,
+  stutter.count.ratio_max = config.defaults$seq_analysis$
+    stutter.count.ratio_max,
+  artifact.count.ratio_max = config.defaults$seq_analysis$
+    artifact.count.ratio_max,
+  reverse_primer_r1 = config.defaults$seq_analysis$
+    reverse_primer_r1,
   ncores = 0,
   analysis_opts,
   summary_opts,
@@ -72,10 +78,12 @@ analyze_dataset <- function(
     ncores <- max(1, as.integer(parallel::detectCores() / 2) - 1)
   }
   analyze.file <- function(fp, locus_attrs, nrepeats,
-                           stutter.count.ratio_max, artifact.count.ratio_max) {
+                           stutter.count.ratio_max, artifact.count.ratio_max,
+                           reverse_primer_r1) {
     seqs <- load_seqs(fp)
     analyze_seqs(seqs, locus_attrs, nrepeats,
-                 stutter.count.ratio_max, artifact.count.ratio_max)
+                 stutter.count.ratio_max, artifact.count.ratio_max,
+                 reverse_primer_r1)
   }
   analyze.entry <- function(entry, analysis_opts, summary_opts,
                             analysis_function, summary_function,
@@ -126,7 +134,8 @@ analyze_dataset <- function(
                                             locus_attrs = locus_attrs,
                                             nrepeats = nrepeats,
                                             stutter.count.ratio_max,
-                                            artifact.count.ratio_max)
+                                            artifact.count.ratio_max,
+                                            reverse_primer_r1)
       names(analyzed_files) <- fps
       raw.results <- parallel::parApply(cluster, dataset, 1, analyze.entry,
                                         analysis_opts = analysis_opts,
@@ -144,7 +153,8 @@ analyze_dataset <- function(
                              locus_attrs = locus_attrs,
                              nrepeats = nrepeats,
                              stutter.count.ratio_max,
-                             artifact.count.ratio_max)
+                             artifact.count.ratio_max,
+                             reverse_primer_r1)
     names(analyzed_files) <- fps
     raw.results <- apply(dataset, 1, analyze.entry,
                          analysis_opts = analysis_opts,

--- a/R/analyze_seqs.R
+++ b/R/analyze_seqs.R
@@ -41,6 +41,9 @@
 #'   considered stutter.
 #' @param artifact.count.ratio_max as for \code{stutter.count.ratio_max} but for
 #'   non-stutter artifact sequences.
+#' @param reverse_primer_r1 Is each reverse primer given in its orientation on
+#'   the forward read?  This is used to determine how the primers and reads
+#'   should be reverse complemented before comparing.
 #'
 #' @return data frame of dereplicated sequences with added annotations.
 #'
@@ -62,8 +65,13 @@
 #'                          num_adjacent_repeats)
 analyze_seqs <- function(
   seqs, locus_attrs, nrepeats,
-  stutter.count.ratio_max = config.defaults$seq_analysis$stutter.count.ratio_max,
-  artifact.count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max) {
+  stutter.count.ratio_max = config.defaults$seq_analysis$
+    stutter.count.ratio_max,
+  artifact.count.ratio_max = config.defaults$seq_analysis$
+    artifact.count.ratio_max,
+  use_reverse_primers = config.defaults$seq_analysis$
+    use_reverse_primers,
+  reverse_primer_r1 = config.defaults$seq_analysis$reverse_primer_r1) {
   # Dereplicate sequences
   tbl <- table(seqs)
   count <- as.integer(tbl)
@@ -79,7 +87,18 @@ analyze_seqs <- function(
   rownames(data) <- NULL
   # Label rows with the apparent locus by checking primer sequences.  Note that
   # this uses the first matching locus for each row.
-  data$MatchingLocus <- find_matching_primer(data, locus_attrs)
+
+  # In the next major release we can add these into the returned data frame, but
+  # for now they can stay internal for compatibility.
+  MatchingPrimerForward <- find_matching_primer(data, locus_attrs)
+  MatchingPrimerReverse <- find_matching_primer(data, locus_attrs, FALSE,
+                                                reverse_primer_r1)
+  data$MatchingLocus <- MatchingPrimerForward
+  if (use_reverse_primers) {
+    data$MatchingLocus[
+      ! (MatchingPrimerForward == MatchingPrimerReverse) %in% TRUE] <- NA
+  }
+
   # Label rows where the sequence content matches the matching locus" repeat
   # motif.
   data$MotifMatch <- check_motif(data, locus_attrs, nrepeats)
@@ -107,24 +126,46 @@ analyze_seqs <- function(
 #' Label STR sequence rows by locus
 #'
 #' Return a factor giving the locus name matching each sample data entry's
-#' matching primer (first found).
+#' matching primer (first found) for either the forward or reverse primers.
 #'
 #' @param sample.data data frame of processed sequence data.
 #' @param locus_attrs data frame of attributes for loci to look for.
+#' @param forward use forward primers, or reverse?
+#' @param reverse_primer_r1 Is each reverse primer given in its orientation on
+#'   the forward read?  This is used to determine how the primers and reads
+#'   should be reverse complemented before comparing.
 #'
 #' @return factor of locus names corresponding the matched primer sequences.
-find_matching_primer <- function(sample.data, locus_attrs) {
+find_matching_primer <- function(sample.data, locus_attrs,
+                                 forward=TRUE, reverse_primer_r1=TRUE) {
+  seqs <- sample.data$Seq
+  if (forward) {
+    primercol <- "Primer"
+  } else {
+    primercol <- "ReversePrimer"
+    seqs <- as.character(
+      Biostrings::reverse(Biostrings::DNAStringSet(sample.data$Seq)))
+  }
   # Separately check each primer.  Is there a slicker way to do this all at
   # once?
   matches <- do.call(cbind, lapply(rownames(locus_attrs), function(locus_name) {
-    primer <- as.character(locus_attrs[locus_name, "Primer"])
-    result <- grepl(primer, substr(sample.data$Seq, 1, nchar(primer) + 10))
+    primer <- as.character(locus_attrs[locus_name, primercol])
+    if (! forward) {
+      primer <- as.character(
+        if (reverse_primer_r1) {
+            Biostrings::reverse(primer)
+        } else {
+            Biostrings::complement(Biostrings::DNAString(primer))
+        }
+      )
+    }
+    result <- grepl(primer, substr(seqs, 1, nchar(primer) + 10))
     c(locus_name)[as.numeric((! result) + 1)]
   }))
   # Collapse that set down to just the first match for each entry.
   first.matches <- apply(matches, 1, function(m) m[match(TRUE, !is.na(m))])
   # Store that as a factor and use the standard locus name levels.
-  factor(first.matches, levels = rownames(locus_attrs))
+  factor(first.matches, levels = unique(locus_attrs$Locus))
 }
 
 #' Check sequences for STR repeats

--- a/R/analyze_seqs.R
+++ b/R/analyze_seqs.R
@@ -41,6 +41,8 @@
 #'   considered stutter.
 #' @param artifact.count.ratio_max as for \code{stutter.count.ratio_max} but for
 #'   non-stutter artifact sequences.
+#' @param use_reverse_primers consider the ReversePrimer column from the locus
+#'   attributes for locus-matching?
 #' @param reverse_primer_r1 Is each reverse primer given in its orientation on
 #'   the forward read?  This is used to determine how the primers and reads
 #'   should be reverse complemented before comparing.

--- a/R/chiimp.R
+++ b/R/chiimp.R
@@ -191,8 +191,12 @@ full_analysis <- function(config, dataset=NULL) {
     allele.names <- load_allele_names(cfg$fp_allele_names)
   results <- analyze_dataset(dataset, locus_attrs,
                              nrepeats = cfg$seq_analysis$nrepeats,
-                             stutter.count.ratio_max = cfg$seq_analysis$stutter.count.ratio_max,
-                             artifact.count.ratio_max = cfg$seq_analysis$artifact.count.ratio_max,
+                             stutter.count.ratio_max = cfg$seq_analysis$
+                               stutter.count.ratio_max,
+                             artifact.count.ratio_max = cfg$seq_analysis$
+                               artifact.count.ratio_max,
+                             reverse_primer_r1 = cfg$seq_analysis$
+                               reverse_primer_r1,
                              ncores = cfg$dataset_analysis$ncores,
                              analysis_opts = cfg$sample_analysis_opts,
                              summary_opts = cfg$sample_summary_opts,

--- a/R/chiimp.R
+++ b/R/chiimp.R
@@ -195,6 +195,8 @@ full_analysis <- function(config, dataset=NULL) {
                                stutter.count.ratio_max,
                              artifact.count.ratio_max = cfg$seq_analysis$
                                artifact.count.ratio_max,
+                             use_reverse_primers = cfg$seq_analysis$
+                               use_reverse_primers,
                              reverse_primer_r1 = cfg$seq_analysis$
                                reverse_primer_r1,
                              ncores = cfg$dataset_analysis$ncores,

--- a/R/configuration.R
+++ b/R/configuration.R
@@ -62,7 +62,9 @@ config.defaults <- list(
   seq_analysis = list(
     nrepeats = 3,
     stutter.count.ratio_max = 1 / 3,
-    artifact.count.ratio_max = 1 / 3
+    artifact.count.ratio_max = 1 / 3,
+    use_reverse_primers = FALSE,
+    reverse_primer_r1 = TRUE
   ),
   sample_analysis_func = "analyze_sample",
   sample_analysis_opts = list(fraction.min = 0.05),

--- a/man/analyze_dataset.Rd
+++ b/man/analyze_dataset.Rd
@@ -7,6 +7,7 @@
 analyze_dataset(dataset, locus_attrs, nrepeats,
   stutter.count.ratio_max = config.defaults$seq_analysis$stutter.count.ratio_max,
   artifact.count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max,
+  use_reverse_primers = config.defaults$seq_analysis$use_reverse_primers,
   reverse_primer_r1 = config.defaults$seq_analysis$reverse_primer_r1,
   ncores = 0, analysis_opts, summary_opts,
   analysis_function = analyze_sample,
@@ -29,6 +30,9 @@ considered stutter (see \code{\link{analyze_seqs}}).}
 
 \item{artifact.count.ratio_max}{as for \code{stutter.count.ratio_max} but for
 non-stutter artifact sequences.}
+
+\item{use_reverse_primers}{consider the ReversePrimer column from the locus
+attributes for locus-matching?}
 
 \item{reverse_primer_r1}{Is each reverse primer given in its orientation on
 the forward read?  (See \code{\link{analyze_seqs}})}

--- a/man/analyze_dataset.Rd
+++ b/man/analyze_dataset.Rd
@@ -7,6 +7,7 @@
 analyze_dataset(dataset, locus_attrs, nrepeats,
   stutter.count.ratio_max = config.defaults$seq_analysis$stutter.count.ratio_max,
   artifact.count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max,
+  reverse_primer_r1 = config.defaults$seq_analysis$reverse_primer_r1,
   ncores = 0, analysis_opts, summary_opts,
   analysis_function = analyze_sample,
   summary_function = summarize_sample, known_alleles = NULL,
@@ -28,6 +29,9 @@ considered stutter (see \code{\link{analyze_seqs}}).}
 
 \item{artifact.count.ratio_max}{as for \code{stutter.count.ratio_max} but for
 non-stutter artifact sequences.}
+
+\item{reverse_primer_r1}{Is each reverse primer given in its orientation on
+the forward read?  (See \code{\link{analyze_seqs}})}
 
 \item{ncores}{integer number of CPU cores to use in parallel for sample
 analysis.  Defaults to one less than half the number of detected cores with

--- a/man/analyze_seqs.Rd
+++ b/man/analyze_seqs.Rd
@@ -6,7 +6,9 @@
 \usage{
 analyze_seqs(seqs, locus_attrs, nrepeats,
   stutter.count.ratio_max = config.defaults$seq_analysis$stutter.count.ratio_max,
-  artifact.count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max)
+  artifact.count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max,
+  use_reverse_primers = config.defaults$seq_analysis$use_reverse_primers,
+  reverse_primer_r1 = config.defaults$seq_analysis$reverse_primer_r1)
 }
 \arguments{
 \item{seqs}{character vector containing sequences.}
@@ -22,6 +24,10 @@ considered stutter.}
 
 \item{artifact.count.ratio_max}{as for \code{stutter.count.ratio_max} but for
 non-stutter artifact sequences.}
+
+\item{reverse_primer_r1}{Is each reverse primer given in its orientation on
+the forward read?  This is used to determine how the primers and reads
+should be reverse complemented before comparing.}
 }
 \value{
 data frame of dereplicated sequences with added annotations.

--- a/man/analyze_seqs.Rd
+++ b/man/analyze_seqs.Rd
@@ -25,6 +25,9 @@ considered stutter.}
 \item{artifact.count.ratio_max}{as for \code{stutter.count.ratio_max} but for
 non-stutter artifact sequences.}
 
+\item{use_reverse_primers}{consider the ReversePrimer column from the locus
+attributes for locus-matching?}
+
 \item{reverse_primer_r1}{Is each reverse primer given in its orientation on
 the forward read?  This is used to determine how the primers and reads
 should be reverse complemented before comparing.}

--- a/man/find_matching_primer.Rd
+++ b/man/find_matching_primer.Rd
@@ -4,17 +4,24 @@
 \alias{find_matching_primer}
 \title{Label STR sequence rows by locus}
 \usage{
-find_matching_primer(sample.data, locus_attrs)
+find_matching_primer(sample.data, locus_attrs, forward = TRUE,
+  reverse_primer_r1 = TRUE)
 }
 \arguments{
 \item{sample.data}{data frame of processed sequence data.}
 
 \item{locus_attrs}{data frame of attributes for loci to look for.}
+
+\item{forward}{use forward primers, or reverse?}
+
+\item{reverse_primer_r1}{Is each reverse primer given in its orientation on
+the forward read?  This is used to determine how the primers and reads
+should be reverse complemented before comparing.}
 }
 \value{
 factor of locus names corresponding the matched primer sequences.
 }
 \description{
 Return a factor giving the locus name matching each sample data entry's
-matching primer (first found).
+matching primer (first found) for either the forward or reverse primers.
 }

--- a/tests/testthat/test_analyze_seqs.R
+++ b/tests/testthat/test_analyze_seqs.R
@@ -47,6 +47,44 @@ with(test_data, {
     expect_equal(chunk$Artifact, as.integer(NA))
   })
 
+  test_that("analyze_seqs can use reverse primers", {
+    # As is, everything still works if we enable the use of reverse primers from
+    # the locus attributes table.
+    seq_data <- analyze_seqs(seqs1$A, locus_attrs, 3,
+                             use_reverse_primers = TRUE)
+    expect_equal(
+      table(seq_data$MatchingLocus),
+      table(factor(c(rep("A", 14), "B", "B", rep(c("1", "2"), 4)),
+                     levels = c("A", "B", "1", "2"))))
+    # Now, try with a reverse primer that won't match up.
+    locus_attrs_mod <- locus_attrs
+    locus_attrs_mod["A", "ReversePrimer"] <- locus_attrs["B", "ReversePrimer"]
+    seq_data <- analyze_seqs(seqs1$A, locus_attrs_mod, 3,
+                             use_reverse_primers = TRUE)
+    # No more locus A matched since we replaced the reverse primer with B's but
+    # the forward primer still matches A's.
+    expect_equal(
+      table(seq_data$MatchingLocus),
+      table(factor(rep(c("1", "2"), 4), levels = c("A", "B", "1", "2"))))
+  })
+
+  test_that("analyze_seqs can use reverse primers and auto-revcmp", {
+    # If we supply the reverse primers in their orientation on R2, it should
+    # still work as expected so long as we specify reverse_primer_r1 = FALSE.
+    primers <- as.character(
+      Biostrings::reverseComplement(
+        Biostrings::DNAStringSet(locus_attrs[, "ReversePrimer"])))
+    locus_attrs_mod <- locus_attrs
+    locus_attrs_mod[, "ReversePrimer"] <- primers
+    seq_data <- analyze_seqs(seqs1$A, locus_attrs_mod, 3,
+                             use_reverse_primers = TRUE,
+                             reverse_primer_r1 = FALSE)
+    expect_equal(
+      table(seq_data$MatchingLocus),
+      table(factor(c(rep("A", 14), "B", "B", rep(c("1", "2"), 4)),
+                   levels = c("A", "B", "1", "2"))))
+  })
+
   test_that("analyze_seqs checks for motif repeats", {
     seqs <- seqs1$A
     seq_data <- analyze_seqs(seqs, locus_attrs, 3)
@@ -109,7 +147,7 @@ with(test_data, {
     stutter <- names(sort(table(s), decreasing = TRUE)[3])
     idx <- s == stutter
     s[idx] <- highest
-    substr(s[idx], nchar(stutter), nchar(stutter)) <- "X"
+    substr(s[idx], nchar(stutter), nchar(stutter)) <- "R"
     # Check that the third entry is marked an artifact of the first
     seq_data <- analyze_seqs(s, locus_attrs, 3)
     expect_equal(seq_data$Artifact, c(NA, NA, 1)[1:24])

--- a/tests/testthat/test_analyze_seqs.R
+++ b/tests/testthat/test_analyze_seqs.R
@@ -134,7 +134,7 @@ with(test_data, {
   test_that("analyze_seqs works with varied threshold for stutter counts", {
     s <- seqs1$A
     s[nchar(s) %in% c(158, 54)] <- s[nchar(s) == 190][1]
-    seq_data <- analyze_seqs(s, locus_attrs, 3, stutter.count.ratio_max = 1/2)
+    seq_data <- analyze_seqs(s, locus_attrs, 3, stutter.count.ratio_max = 1 / 2)
     chunk <- subset(seq_data, !is.na(Stutter))
     expect_equal(chunk$Count, c(443, 2, 2, 2, 1, 1))
     expect_equal(chunk$Stutter, c(2, 2, 2, 2, 4, 4))


### PR DESCRIPTION
This adds support for requiring that both forward and reverse primers match for a given locus, rather than just the forward primer.  Either orientation is supported.  This feature is disabled by default for backwards-compatibility for the time being, but will probably be enabled by default in a later release.  Fixes #42.