### PR TITLE
Handle Bioconductor packages via devtools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - osx
 # https://docs.travis-ci.com/user/languages/r
 language: r
-bioc_packages: msa
 r:
   - oldrel
   - release

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,7 @@ License: file LICENSE
 Encoding: UTF-8
 LazyData: true
 Language: en-US
+biocViews:
 Imports:
   argparser (>= 0.4),
   Biostrings (>= 2.38.4),

--- a/R/installer.R
+++ b/R/installer.R
@@ -168,14 +168,6 @@ install <- function(path_package) {
     install.packages("devtools", repos = "https://cloud.r-project.org")
   }
 
-  if (! haspkg("msa")) {
-    cat("\n")
-    cat("### Installing Bioconductor and MSA\n")
-    cat("\n")
-    source("https://bioconductor.org/biocLite.R")
-    biocLite("msa", suppressUpdates = TRUE)
-  }
-
   cat("\n")
   cat("### Installing CHIIMP\n")
   cat("\n")

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -5,6 +5,8 @@
 # A base R install is assumed to already be present, but all dependencies
 # should be installed automatically here.
 
+set -e
+
 rscript=$(which Rscript)
 pkgdir=$(readlink -f $(dirname $BASH_SOURCE))
 cd "$pkgdir"

--- a/install_mac.command
+++ b/install_mac.command
@@ -5,6 +5,8 @@
 # A base R install is assumed to already be present, but all dependencies
 # should be installed automatically here.
 
+set -e
+
 rscript=$(which Rscript)
 pkgdir=$(dirname $BASH_SOURCE)
 cd "$pkgdir"


### PR DESCRIPTION
This updates the package description so devtools knows to look for Bioconductor packages at install time, simplifying things a bit.