### PR TITLE
Allow arbitrary columns in CSV helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,13 @@ r:
   - bioc-devel
 # Mac OS R devel build URL is out of date, currently.
 # https://travis-ci.community/t/672
+# Also seeing trouble with bioc-devel on Mac OS, but community site is timing
+# out so I'm not sure what the deal is with that one.  (2019-11-20)
 matrix:
   exclude:
     - r: devel
+      os: osx
+    - r: bioc-devel
       os: osx
 cache: packages
 script:

--- a/R/util.R
+++ b/R/util.R
@@ -29,17 +29,22 @@ full_locus_match <- function(sample_data, locus_name) {
 #'
 #' @return character vector of entry identifiers
 make_entry_id <- function(data) {
-  cols.names <- c("Dataset", "Sample", "Name", "Replicate", "Locus")
-  cols.idx <- match(cols.names, colnames(data))
-  cols.idx <- cols.idx[!is.na(cols.idx)]
-  cols.idx <- cols.idx[unlist(lapply(cols.idx, function(x) {
-    !all(is.na(data[, x]))
-  }))]
-  data.names <- data[, cols.idx, drop = FALSE]
-  sapply(1:nrow(data.names), function(nr) {
-    entries <- lapply(data.names[nr, !is.na(data.names[nr, ])], as.character)
-    do.call(paste, as.list(c(entries, sep = "-")))
-  })
+  cols_names <- c("Dataset", "Sample", "Name", "Replicate", "Locus")
+  cols_idx <- match(cols_names, colnames(data))
+  cols_idx <- cols_idx[! is.na(cols_idx)]
+  if (length(cols_idx)) {
+    cols_idx <- cols_idx[unlist(lapply(cols_idx, function(x) {
+      ! all(is.na(data[, x]))
+    }))]
+    data_names <- data[, cols_idx, drop = FALSE]
+    sapply(1:nrow(data_names), function(nr) {
+      entries <- lapply(data_names[nr, ! is.na(data_names[nr, ])], as.character)
+      do.call(paste, as.list(c(entries, sep = "-")))
+    })
+  } else {
+    warning("no recognized columns for entry id")
+    paste0("entry", 1:nrow(data))
+  }
 }
 
 #' Create Row Names for STR Data

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -73,6 +73,23 @@ with(test_data, {
     expect_true(all(locus_attrs == locus_attrs_test))
   })
 
+  test_that("load_csv parses CSV files with unknown columns", {
+    # For cases where our CSV file has none of the recognized column names, it
+    # should still work but just give us generic rownames and a
+    # warning.
+    fp <- tempfile()
+    data_expected <- data.frame(
+      Vec1 = c("A", "D"),
+      Vec2 = c("B", "E"),
+      Vec3 = c("C", "F"),
+      stringsAsFactors = FALSE,
+      row.names = c("entry1", "entry2"))
+    cat("Vec1,Vec2,Vec3\nA,B,C\nD,E,F\n", file = fp)
+    expect_warning(data <- load_csv(fp), "no recognized columns for entry id")
+    file.remove(fp)
+    expect_equal(data, data_expected)
+  })
+
 
   test_that("save_csv saves CSV files", {
     fp <- tempfile()
@@ -84,6 +101,21 @@ with(test_data, {
     expect_equal(locus_attrs_cols, colnames(locus_attrs_test))
     expect_equal(c("A", "B", "1", "2"), rownames(locus_attrs_test))
     expect_true(all(locus_attrs == locus_attrs_test))
+  })
+
+  test_that("save_csv saves CSV files with unknown columns", {
+    # save_csv shouldn't care about the columns but we'll make sure here.
+    fp <- tempfile()
+    data_expected <- data.frame(
+      Vec1 = c("A", "D"),
+      Vec2 = c("B", "E"),
+      Vec3 = c("C", "F"),
+      stringsAsFactors = FALSE)
+    save_csv(data_expected, fp)
+    expect_warning(data <- load_csv(fp))
+    file.remove(fp)
+    rownames(data_expected) <- c("entry1", "entry2")
+    expect_equal(data, data_expected)
   })
 
 


### PR DESCRIPTION
This generalizes CSV loading to allow for all-unrecognized columns and includes a fallback for rownames.  Fixes #51.