### PR TITLE
Release 0.3.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chiimp
 Title: Computational, High-throughput Individual Identification through Microsatellite Profiling
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: person("Jesse", "Connell", email = "ancon@upenn.edu", role = c("aut", "cre"))
 Description: An R package to analyze microsatellites in high-throughput sequencing datasets.
 Depends: R (>= 3.2.3)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# chiimp 0.3.1
+
+ * Fixed icon setup on Mac OS ([#56]).
+
 # chiimp 0.3.0
 
  * Improved icon setup on Mac OS ([#48]).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ high-throughput sequencing datasets.
 
 For automated installation and program usage see [GUIDE.pdf] here or in a
 [released version](https://github.com/ShawHahnLab/chiimp/releases), and the [worked examples].
-The most recent released version is [0.3.0](https://github.com/ShawHahnLab/chiimp/releases/tag/0.3.0).
+The most recent released version is [0.3.1](https://github.com/ShawHahnLab/chiimp/releases/tag/0.3.1).
 For usage as an R package also see the built-in package documentation.  The
 package-level page (`?chiimp`) provides an overview with links to specific
 functions.

--- a/configure
+++ b/configure
@@ -3,6 +3,8 @@
 set -e
 
 # On MacOS, compile the AppleScript for the desktop icon into an application.
+# In the installed package chiimp.app will be at the top level of the package
+# directory.
 if test $(uname -s) = Darwin; then
 	# I tried exec/chiimp.app, but R CMD install seems to skip directories
 	# when copying (which chimp.app actually is)

--- a/exec/chiimp.command
+++ b/exec/chiimp.command
@@ -24,7 +24,8 @@ else
 		rel=$(pwd)
 	fi
 	cd "$cfg_dir"
-	Rscript "$rel/$dir/chiimp" $*
+	logpath=/tmp/chiimp_${USER}_$(date +%Y%m%d%H%M).txt
+	Rscript "$rel/$dir/chiimp" $* |& tee $logpath
 fi
 if [[ "$CHIIMP_AUTOCLOSE" != "yes" ]]; then
 	read -p "Press any key to continue... " -n1 -s

--- a/exec/chiimp.command
+++ b/exec/chiimp.command
@@ -3,7 +3,9 @@
 # Mac OS wrapper to the CHIIMP command-line script.
 #
 # This script will wait for a keypress before exiting since it presumably
-# opened its own terminal window.
+# opened its own terminal window and Terminal may or may not be configured to
+# auto-close windows when commands finish.  If CHIIMP_AUTOCLOSE is set to yes,
+# this is skipped.
 
 # This directory
 dir=$(dirname $BASH_SOURCE)
@@ -24,5 +26,7 @@ else
 	cd "$cfg_dir"
 	Rscript "$rel/$dir/chiimp" $*
 fi
-read -p "Press any key to continue... " -n1 -s
-echo
+if [[ "$CHIIMP_AUTOCLOSE" != "yes" ]]; then
+	read -p "Press any key to continue... " -n1 -s
+	echo
+fi

--- a/exec/chiimp.command
+++ b/exec/chiimp.command
@@ -24,8 +24,7 @@ else
 		rel=$(pwd)
 	fi
 	cd "$cfg_dir"
-	logpath=/tmp/chiimp_${USER}_$(date +%Y%m%d%H%M).txt
-	Rscript "$rel/$dir/chiimp" $* |& tee $logpath
+	Rscript "$rel/$dir/chiimp" "$@"
 fi
 if [[ "$CHIIMP_AUTOCLOSE" != "yes" ]]; then
 	read -p "Press any key to continue... " -n1 -s

--- a/tools/chiimp.AppleScript
+++ b/tools/chiimp.AppleScript
@@ -37,7 +37,7 @@ on process_item(this_item)
 	-- CHIIMP_AUTOCLOSE (this isn't automatically exported to the Terminal
 	-- call but it works to just build it into the string here.)
 	set UnixPath to quoted form of POSIX path of ((path to me as text) & "::")
-	set runCmd to UnixPath & "/exec/chiimp.command " & quoted form of quoted form of POSIX path of this_item
+	set runCmd to UnixPath & "/exec/chiimp.command " & quoted form of POSIX path of this_item
 	set runCmd to "CHIIMP_AUTOCLOSE=" & chiimp_autoclose & " " & runCmd & "; exit"
 	-- Send the command string to the Terminal app, and wait for it to
 	-- complete.

--- a/tools/chiimp.AppleScript
+++ b/tools/chiimp.AppleScript
@@ -31,10 +31,31 @@ end open
 -- Note that the path used will only work on an installed
 -- (non-inst-directory-containing) copy of the package.
 on process_item(this_item)
+	set chiimp_autoclose to system attribute "CHIIMP_AUTOCLOSE"
+	-- Build up a command string that incorporates the full path to the
+	-- .command file, the config file argument, and the special environment variable
+	-- CHIIMP_AUTOCLOSE (this isn't automatically exported to the Terminal
+	-- call but it works to just build it into the string here.)
 	set UnixPath to quoted form of POSIX path of ((path to me as text) & "::")
-	set runCmd to UnixPath & "/../exec/chiimp.command " & quoted form of POSIX path of this_item
+	set runCmd to UnixPath & "/exec/chiimp.command " & quoted form of quoted form of POSIX path of this_item
+	set runCmd to "CHIIMP_AUTOCLOSE=" & chiimp_autoclose & " " & runCmd & "; exit"
+	-- Send the command string to the Terminal app, and wait for it to
+	-- complete.
 	tell application "Terminal"
 		activate
-		do script runCmd
+		-- This is the cleanest way I could find to have the
+		-- AppleScript wait for the shell script to finish.
+		-- https://stackoverflow.com/a/17225439
+		set w to do script runCmd
+		repeat
+			delay 0.1
+			if not busy of w then exit repeat
+		end repeat
 	end tell
+	-- Now use the CHIIMP_AUTOCLOSE environment variable here to decide if
+	-- we should close the terminal window
+	if (chiimp_autoclose is "yes") then
+		-- https://stackoverflow.com/a/57415817
+		tell application "Terminal" to close (get window 1)
+	end if
 end process_item

--- a/tools/travis_install_test.sh
+++ b/tools/travis_install_test.sh
@@ -39,6 +39,15 @@ elif [[ $TRAVIS_OS_NAME == "osx"     ]]; then
 	# automatically when finished so Travis can continue
 	CHIIMP_AUTOCLOSE=yes open -W -a ~/Desktop/CHIIMP config.yml
 	cat /tmp/chiimp_${USER}_$(date +%Y%m%d%H%M).txt
+	# TODO why do we need to do this?  open -W should wait for the command to complete.
+	timeout=60
+	while [[ $timeout -gt 0 ]]; do
+		test -e str-results/summary.csv && break || true
+		echo "waiting for str-results/summary.csv... (${timeout}s)"
+		timeout=$((timeout - 5))
+		sleep 5
+	done
+	# In case we timed out run one final check (and fail)
 	# Check that the results are there
 	test -e str-results/summary.csv
 elif [[ $TRAVIS_OS_NAME == "windows" ]]; then

--- a/tools/travis_install_test.sh
+++ b/tools/travis_install_test.sh
@@ -36,17 +36,18 @@ elif [[ $TRAVIS_OS_NAME == "osx"     ]]; then
 	cd "$scratch"
 	# Simulate drag-and-drop onto the icon, and specify that it should exit
 	# automatically when finished so Travis can continue
-	CHIIMP_AUTOCLOSE=yes open -W -a ~/Desktop/CHIIMP config.yml
-	# Check that the results are there
-	# TODO why do we need to do this?  open -W should wait for the command to complete.
+	# TODO why do we need to call it multiple times?  It's not just the
+	# output that's not there at first, we actually need to try the open
+	# command a couple of times in some cases.
 	timeout=60
 	while [[ $timeout -gt 0 ]]; do
+		CHIIMP_AUTOCLOSE=yes open -W -a ~/Desktop/CHIIMP config.yml
 		test -e str-results/summary.csv && break || true
 		echo "waiting for str-results/summary.csv... (${timeout}s)"
 		timeout=$((timeout - 5))
 		sleep 5
 	done
-	# In case we timed out run one final check (and fail)
+	# In case we timed out, run one final check (and fail, if we did time out)
 	test -e str-results/summary.csv
 elif [[ $TRAVIS_OS_NAME == "windows" ]]; then
 	# (If and when enabled in the Travis config.)

--- a/tools/travis_install_test.sh
+++ b/tools/travis_install_test.sh
@@ -38,7 +38,6 @@ elif [[ $TRAVIS_OS_NAME == "osx"     ]]; then
 	# Simulate drag-and-drop onto the icon, and specify that it should exit
 	# automatically when finished so Travis can continue
 	CHIIMP_AUTOCLOSE=yes open -W -a ~/Desktop/CHIIMP config.yml
-	cat /tmp/chiimp_${USER}_$(date +%Y%m%d%H%M).txt
 	# TODO why do we need to do this?  open -W should wait for the command to complete.
 	timeout=60
 	while [[ $timeout -gt 0 ]]; do

--- a/tools/travis_install_test.sh
+++ b/tools/travis_install_test.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 # This is a helper script for Travis testing.
 # Assumes working directory is the project directory.
 
@@ -38,6 +37,7 @@ elif [[ $TRAVIS_OS_NAME == "osx"     ]]; then
 	# Simulate drag-and-drop onto the icon, and specify that it should exit
 	# automatically when finished so Travis can continue
 	CHIIMP_AUTOCLOSE=yes open -W -a ~/Desktop/CHIIMP config.yml
+	# Check that the results are there
 	# TODO why do we need to do this?  open -W should wait for the command to complete.
 	timeout=60
 	while [[ $timeout -gt 0 ]]; do
@@ -47,7 +47,6 @@ elif [[ $TRAVIS_OS_NAME == "osx"     ]]; then
 		sleep 5
 	done
 	# In case we timed out run one final check (and fail)
-	# Check that the results are there
 	test -e str-results/summary.csv
 elif [[ $TRAVIS_OS_NAME == "windows" ]]; then
 	# (If and when enabled in the Travis config.)

--- a/tools/travis_install_test.sh
+++ b/tools/travis_install_test.sh
@@ -23,11 +23,23 @@ elif [[ $TRAVIS_OS_NAME == "osx"     ]]; then
 	# Desktop icon should be a symbolic link to an existent directory
 	test -d ~/Desktop/CHIIMP
 	test -h ~/Desktop/CHIIMP
-	# TODO we may be able to test the drag-and-drop behavior with a command like this:
-	# open -W -a ~/Desktop/CHIIMP .../config.yml
-	# Currently the .app exits and leaves the Terminal window open, though,
-	# so -W doesn't work as expected.  Changing the AppleScript .app export
-	# options might resolve this.
+	# Desktop icon should run chiimp.command when a config file is dragged
+	# onto it
+	# First, set up inputs in a temp location.
+	# TODO This is largely a repeat of what's in demo.sh
+	cd "$(dirname $BASH_SOURCE)"
+	dir=$(pwd -P)
+	inst="../inst"
+	scratch=$(mktemp -d)
+	R --vanilla -q -e "devtools::load_all('..', quiet=T); test_data\$write_seqs(test_data\$seqs, '$scratch/str-dataset', 'Replicate1-Sample%s-%s.fasta')" > /dev/null
+	cp "$dir/$inst/example_locus_attrs.csv" "$scratch/locus_attrs.csv"
+	cp "$dir/$inst/example_config.yml" "$scratch/config.yml"
+	cd "$scratch"
+	# Simulate drag-and-drop onto the icon, and specify that it should exit
+	# automatically when finished so Travis can continue
+	CHIIMP_AUTOCLOSE=yes open -W -a ~/Desktop/CHIIMP config.yml
+	# Check that the results are there
+	test -e str-results/summary.csv
 elif [[ $TRAVIS_OS_NAME == "windows" ]]; then
 	# (If and when enabled in the Travis config.)
 	yes | ./install_windows.cmd

--- a/tools/travis_install_test.sh
+++ b/tools/travis_install_test.sh
@@ -38,6 +38,7 @@ elif [[ $TRAVIS_OS_NAME == "osx"     ]]; then
 	# Simulate drag-and-drop onto the icon, and specify that it should exit
 	# automatically when finished so Travis can continue
 	CHIIMP_AUTOCLOSE=yes open -W -a ~/Desktop/CHIIMP config.yml
+	cat /tmp/chiimp_${USER}_$(date +%Y%m%d%H%M).txt
 	# Check that the results are there
 	test -e str-results/summary.csv
 elif [[ $TRAVIS_OS_NAME == "windows" ]]; then


### PR DESCRIPTION
This is a hotfix to get the Mac OS Desktop icon working again.  There's a lot of stuff changed in the continuous integration files but the fix itself is as simple as replacing `/../exec/chiimp.command` with `/exec/chiimp.command` in chiimp.AppleScript.  Fixes #55.