### PR TITLE
Make plot_dist_mat handle pheatmap arguments correctly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
+# chiimp dev
+
+ * Fixed handling of extra pheatmap arguments in `plot_dist_mat` ([#62])
+
+[#62]: https://github.com/ShawHahnLab/chiimp/pull/62
+
 # chiimp 0.3.1
 
  * Fixed icon setup on Mac OS ([#56]).
+
+[#56]: https://github.com/ShawHahnLab/chiimp/pull/56
 
 # chiimp 0.3.0
 

--- a/R/report.R
+++ b/R/report.R
@@ -302,15 +302,15 @@ plot_dist_mat <- function(dist_mat, num.alleles=max(dist_mat),
                fontsize = fontsize)
   if (nrow(dist_mat) == ncol(dist_mat)) {
     args <- c(args,
-              clustering_distance_rows = stats::as.dist(dist_mat),
-              clustering_distance_cols = stats::as.dist(dist_mat))
+              list(clustering_distance_rows = stats::as.dist(dist_mat)),
+              list(clustering_distance_cols = stats::as.dist(dist_mat)))
   } else {
     args <- c(args,
               cluster_cols = FALSE,
               cluster_rows = FALSE)
   }
 
-  do.call(pheatmap::pheatmap, c(args, ...))
+  do.call(pheatmap::pheatmap, c(args, list(...)))
 }
 
 

--- a/tests/testthat/test_report.R
+++ b/tests/testthat/test_report.R
@@ -20,6 +20,43 @@ with(test_data, {
     })
   })
 
+
+# test plot_dist_mat ------------------------------------------------------
+
+  test_that("plot_dist_mat plots heatmap of distance matrix", {
+    with(results_summary_data, {
+      dist_mat <- make_dist_mat(test_data$results_summary_data$results$summary)
+      fp_img <- tempfile()
+      png(fp_img)
+      plot_data <- plot_dist_mat(dist_mat)
+      dev.off()
+      unlink(x = fp_img)
+      # check a few basic things on the pheatmap object
+      expect_equal(class(plot_data), "pheatmap")
+      expect_equal(
+        plot_data$gtable$layout$name,
+        c("col_tree", "matrix", "col_names", "row_names", "legend"))
+    })
+  })
+
+  test_that("plot_dist_mat can take pheatmap arguments", {
+    with(results_summary_data, {
+      dist_mat <- make_dist_mat(test_data$results_summary_data$results$summary)
+      fp_img <- tempfile()
+      png(fp_img)
+      annotations <- data.frame(
+        Attribute=LETTERS[seq_along(rownames(dist_mat))])
+      rownames(annotations) <- rownames(dist_mat)
+      plot_data <- plot_dist_mat(dist_mat, annotation_col = annotations)
+      dev.off()
+      unlink(x = fp_img)
+      # we should still get a pheatmap object back, but this time with the
+      # annotation info built into the plot data
+      expect_equal(class(plot_data), "pheatmap")
+      expect_true("col_annotation" %in% plot_data$gtable$layout$name)
+    })
+  })
+
 # test tabulate_allele_names ----------------------------------------------
 
   test_that("tabulate_allele_names produces expected data frame", {


### PR DESCRIPTION
Corrects the list handling in `plot_dist_mat` to properly pass along any extra arguments to `pheatmap`.  Fixes #61.