### PR TITLE
Automatically create parent directories when saving tables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
 # chiimp dev
 
+ * Made `save_csv` automatically create any parent directories as needed
+   ([#63])
  * Fixed handling of extra pheatmap arguments in `plot_dist_mat` ([#62])
 
+[#63]: https://github.com/ShawHahnLab/chiimp/pull/63
 [#62]: https://github.com/ShawHahnLab/chiimp/pull/62
 
 # chiimp 0.3.1

--- a/R/io.R
+++ b/R/io.R
@@ -363,8 +363,6 @@ load_seqs <- function(fp) {
 #'
 #' @export
 save_results_summary <- function(results_summary, fp) {
-  if (!dir.exists(dirname(fp)))
-    dir.create(dirname(fp), recursive = TRUE)
   save_csv(results_summary, fp)
 }
 
@@ -428,12 +426,6 @@ save_seqfile_data <- function(results_file_data, dp) {
   fps_rel <- remove_shared_root_dir(names(results_file_data))
   invisible(lapply(names(results_file_data), function(n) {
     fp_this <- fps_rel[n]
-    dp_this <- ifelse(dirname(fp_this) != ".",
-                      file.path(dp, dirname(fp_this)),
-                      dp)
-    if (! dir.exists(dp_this)) {
-      dir.create(dp_this, recursive = TRUE)
-    }
     fp <- file.path(dp, paste0(fp_this, ".csv"))
     save_csv(results_file_data[[n]], fp, quote = FALSE)
   }))
@@ -451,8 +443,6 @@ save_seqfile_data <- function(results_file_data, dp) {
 #'
 #' @export
 save_sample_data <- function(results_data, dp) {
-  if (!dir.exists(dp))
-    dir.create(dp, recursive = TRUE)
   invisible(lapply(names(results_data), function(n) {
     fp <- file.path(dp, paste0(n, ".csv"))
     save_csv(results_data[[n]], fp, quote = FALSE)
@@ -570,8 +560,6 @@ save_histograms <- function(results, dp, image.func="png",
 #'
 #' @export
 save_dist_mat <- function(dist_mat, fp) {
-  if (!dir.exists(dirname(fp)))
-    dir.create(dirname(fp), recursive = TRUE)
   save_csv(dist_mat, fp)
 }
 
@@ -581,6 +569,6 @@ save_dist_mat <- function(dist_mat, fp) {
 
 # Create all parent directories as needed
 mkparents <- function(fp) {
-    if (!dir.exists(dirname(fp)))
-          dir.create(dirname(fp), recursive = TRUE)
+  if (!dir.exists(dirname(fp)))
+    dir.create(dirname(fp), recursive = TRUE)
 }

--- a/R/io.R
+++ b/R/io.R
@@ -68,6 +68,7 @@ load_csv <- function(fp, ...) {
 #' @param data data frame to save to CSV file
 #' @export
 save_csv <- function(data, fp, ...) {
+  mkparents(fp)
   utils::write.table(data,
                      file = fp,
                      sep = ",",
@@ -572,4 +573,14 @@ save_dist_mat <- function(dist_mat, fp) {
   if (!dir.exists(dirname(fp)))
     dir.create(dirname(fp), recursive = TRUE)
   save_csv(dist_mat, fp)
+}
+
+
+# Helpers -----------------------------------------------------------------
+
+
+# Create all parent directories as needed
+mkparents <- function(fp) {
+    if (!dir.exists(dirname(fp)))
+          dir.create(dirname(fp), recursive = TRUE)
 }

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -118,6 +118,20 @@ with(test_data, {
     expect_equal(data, data_expected)
   })
 
+  test_that("save_csv makes parent dirs when saving", {
+    # the parent directories here don't yet exist, so for this to work,
+    # save_csv will need to create them
+    fp <- file.path(tempfile(), basename(tempfile()))
+    save_csv(locus_attrs, fp)
+    locus_attrs_test <- load_locus_attrs(fp)
+    file.remove(fp)
+    expect_equal(nrow(locus_attrs_test), nrow(locus_attrs))
+    expect_equal(ncol(locus_attrs_test), ncol(locus_attrs))
+    expect_equal(locus_attrs_cols, colnames(locus_attrs_test))
+    expect_equal(c("A", "B", "1", "2"), rownames(locus_attrs_test))
+    expect_true(all(locus_attrs == locus_attrs_test))
+  })
+
 
 # test load_locus_attrs ---------------------------------------------------
 


### PR DESCRIPTION
Parent directories are now recursively created as needed in `save_csv`.  Fixes #53.