### PR TITLE
Support labeling untested sample/locus combinations in genotype summary tables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@
 version: 2.1
 jobs:
   build:
+    parameters:
+      rversion:
+        type: string
     docker:
       - image: rocker/verse:<<parameters.rversion>>
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,3 +107,10 @@ jobs:
       - run:
           name: "Run install test script"
           command: bash tools/circleci_install_test.sh
+
+workflows:
+  version: 2
+  build_all:
+    jobs:
+      - build-r-4
+      - build-r-3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,57 @@
 # skipping that part of the package check with --no-manual.
 version: 2.1
 jobs:
-  build:
+  build-r-4:
     docker:
       - image: rocker/verse:4.1.2
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "DESCRIPTION" }}
+      - run:
+          name: Install package dependencies
+          command: R -e "devtools::install_deps(dep = TRUE)"
+      - save_cache:
+          key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "DESCRIPTION" }}
+          paths:
+            - "/usr/local/lib/R/site-library"
+      - run:
+          name: Build package
+          command: R CMD build .
+      - run:
+          name: Check package
+          command: R CMD check --no-manual *tar.gz
+      - store_artifacts:
+          name: "Store Artifacts: 00check.log"
+          path: chiimp.Rcheck/00check.log
+      - store_artifacts:
+          name: "Store Artifacts: 00install.out"
+          path: chiimp.Rcheck/00install.out
+      - run:
+          name: "Run demo script"
+          command: bash exec/demo.sh $PWD/demo-files
+      - store_artifacts:
+          name: "Store Artifacts: demo: report"
+          path: demo-files/str-results/report.html
+      - store_artifacts:
+          name: "Store Artifacts: demo: summary"
+          path: demo-files/str-results/summary.csv
+      - run:
+          name: "Run demo script - empty case"
+          command: bash exec/demo_empty.sh $PWD/demo-empty-files
+      - store_artifacts:
+          name: "Store Artifacts: empty demo: report"
+          path: demo-empty-files/str-results/report.html
+      - store_artifacts:
+          name: "Store Artifacts: empty demo: summary"
+          path: demo-empty-files/str-results/summary.csv
+      - run:
+          name: "Run install test script"
+          command: bash tools/circleci_install_test.sh
+  build-r-3:
+    docker:
+      - image: rocker/verse:3.6.3
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,57 +11,9 @@
 # skipping that part of the package check with --no-manual.
 version: 2.1
 jobs:
-  build-r-4:
+  build:
     docker:
-      - image: rocker/verse:4.1.2
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "DESCRIPTION" }}
-      - run:
-          name: Install package dependencies
-          command: R -e "devtools::install_deps(dep = TRUE)"
-      - save_cache:
-          key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "DESCRIPTION" }}
-          paths:
-            - "/usr/local/lib/R/site-library"
-      - run:
-          name: Build package
-          command: R CMD build .
-      - run:
-          name: Check package
-          command: R CMD check --no-manual *tar.gz
-      - store_artifacts:
-          name: "Store Artifacts: 00check.log"
-          path: chiimp.Rcheck/00check.log
-      - store_artifacts:
-          name: "Store Artifacts: 00install.out"
-          path: chiimp.Rcheck/00install.out
-      - run:
-          name: "Run demo script"
-          command: bash exec/demo.sh $PWD/demo-files
-      - store_artifacts:
-          name: "Store Artifacts: demo: report"
-          path: demo-files/str-results/report.html
-      - store_artifacts:
-          name: "Store Artifacts: demo: summary"
-          path: demo-files/str-results/summary.csv
-      - run:
-          name: "Run demo script - empty case"
-          command: bash exec/demo_empty.sh $PWD/demo-empty-files
-      - store_artifacts:
-          name: "Store Artifacts: empty demo: report"
-          path: demo-empty-files/str-results/report.html
-      - store_artifacts:
-          name: "Store Artifacts: empty demo: summary"
-          path: demo-empty-files/str-results/summary.csv
-      - run:
-          name: "Run install test script"
-          command: bash tools/circleci_install_test.sh
-  build-r-3:
-    docker:
-      - image: rocker/verse:3.6.3
+      - image: rocker/verse:<<parameters.rversion>>
     steps:
       - checkout
       - restore_cache:
@@ -112,5 +64,7 @@ workflows:
   version: 2
   build_all:
     jobs:
-      - build-r-4
-      - build-r-3
+      - build:
+          matrix:
+            parameters:
+              rversion: ["3.6.3", "4.1.2"]

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
 Remotes:
   github::sherrillmix/dnar,
   github::sherrillmix/dnaplotr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1
 Suggests:
   testthat,
   roxygen2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,12 @@
 # chiimp dev
 
+ * Added option for custom text in genotype summary tables for untested
+   locus/sample combinations ([#64])
  * Made `save_csv` automatically create any parent directories as needed
    ([#63])
  * Fixed handling of extra pheatmap arguments in `plot_dist_mat` ([#62])
 
+[#64]: https://github.com/ShawHahnLab/chiimp/pull/64
 [#63]: https://github.com/ShawHahnLab/chiimp/pull/63
 [#62]: https://github.com/ShawHahnLab/chiimp/pull/62
 

--- a/R/configuration.R
+++ b/R/configuration.R
@@ -85,6 +85,10 @@ config.defaults <- list(
   report.group_samples = FALSE,
   # Text to use for NA entries in Replicates column of tables (i.e. Pooled)
   report.na.replicates = "",
+  # Text to use for NA allele enries in tables (when the Sample+Locus
+  # combination was not present at all, as opposed to when a genotype could not
+  # be determined)
+  report.na.alleles = "",
   # Parameters controlling how identifications are reported: dist_range is how
   # closeby (to the closest case) the next-nearest individuals must be to be
   # listed as similar to a sample, and dist_max is the maximum distance for a

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -49,11 +49,13 @@ kable_genotypes <- function(data, group_samples=FALSE) {
 # Write markdown tables to standard output for report_genotypes()
 rmd_kable_genotypes <- function(results,
                                 na.replicates="",
+                                na.alleles="",
                                 locus_chunks=NULL,
                                 group_samples=FALSE,
                                 closest=NULL) {
   tbl <- report_genotypes(results = results,
                    na.replicates = na.replicates,
+                   na.alleles = na.alleles,
                    closest = closest)
   if (!is.null(locus_chunks)) {
     chunk_up(data = tbl,

--- a/R/report.R
+++ b/R/report.R
@@ -78,6 +78,7 @@ tabulate_allele_names <- function(data, extra_cols=NULL) {
 #' @param results list of results data as produced by \code{analyze_dataset}.
 #' @param na.replicates text to replace NA entries with for the Replicates
 #'     column.
+#' @param na.alleles text to replace NA entries with for the allele names
 #' @param closest list of closest matches as produced by
 #'   \code{\link{find_closest_matches}}.
 #'
@@ -85,6 +86,7 @@ tabulate_allele_names <- function(data, extra_cols=NULL) {
 #' @export
 report_genotypes <- function(results,
                              na.replicates="",
+                             na.alleles="",
                              closest=NULL) {
   tbl <- tabulate_allele_names(data = results$summary,
                                extra_cols = c("Sample", "Replicate"))
@@ -109,7 +111,7 @@ report_genotypes <- function(results,
   else
     tbl$Replicate[is.na(tbl$Replicate)] <- na.replicates
   # Blank out any remaining NA values
-  tbl[is.na(tbl)] <- ""
+  tbl[is.na(tbl)] <- na.alleles
 
   tbl
 }

--- a/R/report.R
+++ b/R/report.R
@@ -21,7 +21,8 @@ normalize_alleles <- function(data) {
 #' Wide table of allele names vs loci
 #'
 #' Allele pairs are shown in a standardized order with homozygous entries shown
-#' twice.
+#' twice.  NA allele names in the input are converted to empty strings while NA
+#' is given for missing sample/locus combinations.
 #'
 #' @param data data frame containing Allele1Name and Allele2Name columns such as
 #'   the first list item produced by \code{\link{analyze_dataset}}.  If allele
@@ -32,7 +33,9 @@ normalize_alleles <- function(data) {
 #'
 #' @return wide format data frame with sample entries on rows and loci on
 #'   columns.  An ID column will label sample entries by whichever columns were
-#'   provided in the input (see \code{\link{make_entry_id}}).
+#'   provided in the input (see \code{\link{make_entry_id}}).  Empty strings are
+#'   given for NA allele names, while NA is given for any implicitly missing
+#'   locus/sample combinations.
 #'
 #' @export
 tabulate_allele_names <- function(data, extra_cols=NULL) {

--- a/inst/report/report_genotypes.Rmd
+++ b/inst/report/report_genotypes.Rmd
@@ -3,6 +3,7 @@
 ```{r genotypes, results="asis"}
 rmd_kable_genotypes(results,
                     na.replicates = report.na.replicates,
+                    na.alleles = report.na.alleles,
                     locus_chunks = report.locus_chunks,
                     group_samples = report.group_samples,
                     closest = results$closest_matches)

--- a/man/analyze_dataset.Rd
+++ b/man/analyze_dataset.Rd
@@ -4,15 +4,22 @@
 \alias{analyze_dataset}
 \title{Analyze all samples in a dataset}
 \usage{
-analyze_dataset(dataset, locus_attrs, nrepeats,
+analyze_dataset(
+  dataset,
+  locus_attrs,
+  nrepeats,
   stutter.count.ratio_max = config.defaults$seq_analysis$stutter.count.ratio_max,
   artifact.count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max,
   use_reverse_primers = config.defaults$seq_analysis$use_reverse_primers,
   reverse_primer_r1 = config.defaults$seq_analysis$reverse_primer_r1,
-  ncores = 0, analysis_opts, summary_opts,
+  ncores = 0,
+  analysis_opts,
+  summary_opts,
   analysis_function = analyze_sample,
-  summary_function = summarize_sample, known_alleles = NULL,
-  name_args = list())
+  summary_function = summarize_sample,
+  known_alleles = NULL,
+  name_args = list()
+)
 }
 \arguments{
 \item{dataset}{data frame of sample details as produced by

--- a/man/analyze_seqs.Rd
+++ b/man/analyze_seqs.Rd
@@ -4,11 +4,15 @@
 \alias{analyze_seqs}
 \title{Analyze a set of STR sequences}
 \usage{
-analyze_seqs(seqs, locus_attrs, nrepeats,
+analyze_seqs(
+  seqs,
+  locus_attrs,
+  nrepeats,
   stutter.count.ratio_max = config.defaults$seq_analysis$stutter.count.ratio_max,
   artifact.count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max,
   use_reverse_primers = config.defaults$seq_analysis$use_reverse_primers,
-  reverse_primer_r1 = config.defaults$seq_analysis$reverse_primer_r1)
+  reverse_primer_r1 = config.defaults$seq_analysis$reverse_primer_r1
+)
 }
 \arguments{
 \item{seqs}{character vector containing sequences.}

--- a/man/config.defaults.Rd
+++ b/man/config.defaults.Rd
@@ -4,7 +4,9 @@
 \name{config.defaults}
 \alias{config.defaults}
 \title{Default microsatellite configuration}
-\format{An object of class \code{list} of length 23.}
+\format{
+An object of class \code{list} of length 24.
+}
 \usage{
 config.defaults
 }

--- a/man/find_artifact.Rd
+++ b/man/find_artifact.Rd
@@ -4,8 +4,11 @@
 \alias{find_artifact}
 \title{Check for non-stutter PCR artifacts between sequences}
 \usage{
-find_artifact(sample.data, locus_attrs,
-  count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max)
+find_artifact(
+  sample.data,
+  locus_attrs,
+  count.ratio_max = config.defaults$seq_analysis$artifact.count.ratio_max
+)
 }
 \arguments{
 \item{sample.data}{data frame of processed sample data.}

--- a/man/find_matching_primer.Rd
+++ b/man/find_matching_primer.Rd
@@ -4,8 +4,12 @@
 \alias{find_matching_primer}
 \title{Label STR sequence rows by locus}
 \usage{
-find_matching_primer(sample.data, locus_attrs, forward = TRUE,
-  reverse_primer_r1 = TRUE)
+find_matching_primer(
+  sample.data,
+  locus_attrs,
+  forward = TRUE,
+  reverse_primer_r1 = TRUE
+)
 }
 \arguments{
 \item{sample.data}{data frame of processed sequence data.}

--- a/man/find_stutter.Rd
+++ b/man/find_stutter.Rd
@@ -4,8 +4,11 @@
 \alias{find_stutter}
 \title{Check for PCR stutter between sequences}
 \usage{
-find_stutter(sample.data, locus_attrs,
-  count.ratio_max = config.defaults$seq_analysis$stutter.count.ratio_max)
+find_stutter(
+  sample.data,
+  locus_attrs,
+  count.ratio_max = config.defaults$seq_analysis$stutter.count.ratio_max
+)
 }
 \arguments{
 \item{sample.data}{data frame of processed sample data.}

--- a/man/histogram.Rd
+++ b/man/histogram.Rd
@@ -4,10 +4,14 @@
 \alias{histogram}
 \title{Plot histogram of STR sequences}
 \usage{
-histogram(seq_data, sample_data = NULL,
+histogram(
+  seq_data,
+  sample_data = NULL,
   main = "Number of Reads by Sequence Length",
-  xlim = range(seq_data$Length), cutoff_fraction = NULL,
-  render = TRUE)
+  xlim = range(seq_data$Length),
+  cutoff_fraction = NULL,
+  render = TRUE
+)
 }
 \arguments{
 \item{seq_data}{data frame of dereplicated sequences as created by

--- a/man/make_dist_mat_known.Rd
+++ b/man/make_dist_mat_known.Rd
@@ -4,8 +4,11 @@
 \alias{make_dist_mat_known}
 \title{Make distance matrix for samples to known genotypes}
 \usage{
-make_dist_mat_known(results_summary, genotypes.known,
-  dist.func = calc_genotype_distance)
+make_dist_mat_known(
+  results_summary,
+  genotypes.known,
+  dist.func = calc_genotype_distance
+)
 }
 \arguments{
 \item{results_summary}{cross-sample summary data frame as produced by

--- a/man/plot_dist_mat.Rd
+++ b/man/plot_dist_mat.Rd
@@ -4,8 +4,12 @@
 \alias{plot_dist_mat}
 \title{Plot Distance Matrix}
 \usage{
-plot_dist_mat(dist_mat, num.alleles = max(dist_mat),
-  dist.display_thresh = round(num.alleles * 2/3), ...)
+plot_dist_mat(
+  dist_mat,
+  num.alleles = max(dist_mat),
+  dist.display_thresh = round(num.alleles * 2/3),
+  ...
+)
 }
 \arguments{
 \item{dist_mat}{distance matrix as produced by

--- a/man/plot_heatmap.Rd
+++ b/man/plot_heatmap.Rd
@@ -4,8 +4,14 @@
 \alias{plot_heatmap}
 \title{Render heatmap of STR attribute across samples and loci}
 \usage{
-plot_heatmap(results, attribute, label.by = c("Allele1Length",
-  "Allele2Length"), color = c("white", "pink"), breaks = NA, ...)
+plot_heatmap(
+  results,
+  attribute,
+  label.by = c("Allele1Length", "Allele2Length"),
+  color = c("white", "pink"),
+  breaks = NA,
+  ...
+)
 }
 \arguments{
 \item{results}{combined results list}

--- a/man/prepare_dataset.Rd
+++ b/man/prepare_dataset.Rd
@@ -4,8 +4,13 @@
 \alias{prepare_dataset}
 \title{Extract Sample Attributes from Filenames}
 \usage{
-prepare_dataset(dp, pattern, ord = c(1, 2, 3), autorep = FALSE,
-  locusmap = NULL)
+prepare_dataset(
+  dp,
+  pattern,
+  ord = c(1, 2, 3),
+  autorep = FALSE,
+  locusmap = NULL
+)
 }
 \arguments{
 \item{dp}{directory path to search for matching data files.}

--- a/man/report_genotypes.Rd
+++ b/man/report_genotypes.Rd
@@ -4,13 +4,15 @@
 \alias{report_genotypes}
 \title{Create genotype summary table}
 \usage{
-report_genotypes(results, na.replicates = "", closest = NULL)
+report_genotypes(results, na.replicates = "", na.alleles = "", closest = NULL)
 }
 \arguments{
 \item{results}{list of results data as produced by \code{analyze_dataset}.}
 
 \item{na.replicates}{text to replace NA entries with for the Replicates
 column.}
+
+\item{na.alleles}{text to replace NA entries with for the allele names}
 
 \item{closest}{list of closest matches as produced by
 \code{\link{find_closest_matches}}.}

--- a/man/sample_analysis_funcs.Rd
+++ b/man/sample_analysis_funcs.Rd
@@ -4,7 +4,9 @@
 \name{sample_analysis_funcs}
 \alias{sample_analysis_funcs}
 \title{Versions of analyze_sample}
-\format{An object of class \code{character} of length 3.}
+\format{
+An object of class \code{character} of length 3.
+}
 \usage{
 sample_analysis_funcs
 }

--- a/man/sample_summary_funcs.Rd
+++ b/man/sample_summary_funcs.Rd
@@ -4,7 +4,9 @@
 \name{sample_summary_funcs}
 \alias{sample_summary_funcs}
 \title{Versions of summarize_sample}
-\format{An object of class \code{character} of length 2.}
+\format{
+An object of class \code{character} of length 2.
+}
 \usage{
 sample_summary_funcs
 }

--- a/man/save_alignment_images.Rd
+++ b/man/save_alignment_images.Rd
@@ -4,8 +4,14 @@
 \alias{save_alignment_images}
 \title{Save alignment visualizations to image files}
 \usage{
-save_alignment_images(alignments, dp, image.func = "png", width = 1600,
-  height = 1200, res = 150)
+save_alignment_images(
+  alignments,
+  dp,
+  image.func = "png",
+  width = 1600,
+  height = 1200,
+  res = 150
+)
 }
 \arguments{
 \item{alignments}{list of MSA alignment objects, such as created by

--- a/man/save_histograms.Rd
+++ b/man/save_histograms.Rd
@@ -4,8 +4,14 @@
 \alias{save_histograms}
 \title{Save sequence histogram visualizations to image files}
 \usage{
-save_histograms(results, dp, image.func = "png", width = 1600,
-  height = 1200, res = 150)
+save_histograms(
+  results,
+  dp,
+  image.func = "png",
+  width = 1600,
+  height = 1200,
+  res = 150
+)
 }
 \arguments{
 \item{results}{list of results as created by \code{\link{analyze_dataset}}.}

--- a/man/summarize_genotypes.Rd
+++ b/man/summarize_genotypes.Rd
@@ -4,8 +4,7 @@
 \alias{summarize_genotypes}
 \title{Create Summary Genotype Table}
 \usage{
-summarize_genotypes(results_summary, vars = c("Allele1Seq",
-  "Allele2Seq"))
+summarize_genotypes(results_summary, vars = c("Allele1Seq", "Allele2Seq"))
 }
 \arguments{
 \item{results_summary}{cross-sample summary data frame as produced by

--- a/man/tabulate_allele_names.Rd
+++ b/man/tabulate_allele_names.Rd
@@ -18,9 +18,12 @@ loci for a given entry.}
 \value{
 wide format data frame with sample entries on rows and loci on
   columns.  An ID column will label sample entries by whichever columns were
-  provided in the input (see \code{\link{make_entry_id}}).
+  provided in the input (see \code{\link{make_entry_id}}).  Empty strings are
+  given for NA allele names, while NA is given for any implicitly missing
+  locus/sample combinations.
 }
 \description{
 Allele pairs are shown in a standardized order with homozygous entries shown
-twice.
+twice.  NA allele names in the input are converted to empty strings while NA
+is given for missing sample/locus combinations.
 }

--- a/man/test_data.Rd
+++ b/man/test_data.Rd
@@ -4,7 +4,9 @@
 \name{test_data}
 \alias{test_data}
 \title{Helper Data for Tests}
-\format{An object of class \code{list} of length 17.}
+\format{
+An object of class \code{list} of length 17.
+}
 \usage{
 test_data
 }

--- a/tests/testthat/test_report.R
+++ b/tests/testthat/test_report.R
@@ -225,7 +225,7 @@ with(test_data, {
     # default so should missing results
     # (Sample 3 Locus A not given; Sample 2 Locus A blank results)
     results$summary[
-      11, c("Allele1Seq", "Allele2Seq", "Allele1Name", "Alelel2Name")] <- NA
+      11, c("Allele1Seq", "Allele2Seq", "Allele1Name", "Allele2Name")] <- NA
     results$summary <- results$summary[-12, ]
     tbl <- report_genotypes(results)
     tbl_known[2:3, 8:9] <- ""


### PR DESCRIPTION
Adds a configuration option for labeling `NA` entries in the genotype summary tables in reports, as handled by `report_genotypes`.  Previously this was hardcoded as an empty string, but can now be set to any string in the configuration as `report.na.alleles` (for example as a unicode symbol like ⃠).  Fixes #10.  Also extends CircleCI testing to include both R version 3 and version 4.