### PR TITLE
Handle missing data in histogram rendering

### DIFF
--- a/R/histogram.R
+++ b/R/histogram.R
@@ -96,7 +96,7 @@ str_hist_setup <- function(seq_data, sample_data = NULL) {
 #'
 #' Render prepared histogram data to the display device.
 #'
-#' @param bars data frames of counts-vs-lengths as prepared by
+#' @param bars list of data frames of counts-vs-lengths as prepared by
 #' \code{\link{str_hist_setup}}.
 #' @param main title of the plot.
 #' @param xlim numeric range for x-axis.
@@ -120,15 +120,17 @@ str_hist_render <- function(bars, main, xlim, cutoff_fraction) {
   lwd <- max(1, get_px_width()) # at least one pixel
 
   for (nm in names(bars)) {
-    graphics::points(bars[[nm]]$Length,
-                     bars[[nm]]$Count,
-                     type = "h",
-                     col = categories[nm, "col"],
-                     lend = 1,
-                     lwd = lwd)
+    if (nrow(bars[[nm]]) > 0) {
+      graphics::points(bars[[nm]]$Length,
+                       bars[[nm]]$Count,
+                       type = "h",
+                       col = categories[nm, "col"],
+                       lend = 1,
+                       lwd = lwd)
+    }
   }
 
-  if (! is.null(bars$filt)) {
+  if (! is.null(bars$filt) && nrow(bars$filt) > 0) {
     # Draw threshold
     cutoff <- (cutoff_fraction * sum(bars$filt$Count))[1]
     if (! is.na(cutoff)) {

--- a/tests/testthat/test_histogram.R
+++ b/tests/testthat/test_histogram.R
@@ -62,7 +62,8 @@ with(test_data, {
     data_summary <- results_summary_data$results$summary["3-2", ]
     seq_data <- results_summary_data$results$files[[data_summary$Filename]][0, ]
     png(fp_devnull)
-    output <- histogram(seq_data = seq_data)
+    expect_silent(
+      output <- histogram(seq_data = seq_data))
     dev.off()
     output_expected <- within(list(), {
       orig <- data.frame(Length = as.integer(NA), Count = as.integer(NA))[0, ]
@@ -77,9 +78,10 @@ with(test_data, {
     seq_data <- results_summary_data$results$files[[data_summary$Filename]]
     sample_data <- results_summary_data$results$samples[["3-2"]][0, ]
     png(fp_devnull)
-    output <- histogram(seq_data = seq_data,
-                       sample_data = sample_data,
-                       cutoff_fraction = 0.05)
+    expect_silent(
+      output <- histogram(seq_data = seq_data,
+                          sample_data = sample_data,
+                          cutoff_fraction = 0.05))
     dev.off()
     # With sample_data data empty but still provided we should still have the
     # same structure of output, just with zero-row data frames in most of the

--- a/tests/testthat/test_histogram.R
+++ b/tests/testthat/test_histogram.R
@@ -9,10 +9,11 @@ with(test_data, {
     data_summary <- results_summary_data$results$summary["3-2", ]
     seq_data <- results_summary_data$results$files[[data_summary$Filename]]
     sample_data <- results_summary_data$results$samples[["3-2"]]
+    png(fp_devnull)
     output <- histogram(seq_data = seq_data,
                        sample_data = sample_data,
-                       cutoff_fraction = 0.05,
-                       render = FALSE)
+                       cutoff_fraction = 0.05)
+    dev.off()
     # The return value of histogram() should be a list of data frames organized
     # by category.
     output_expected <- within(list(), {
@@ -43,8 +44,9 @@ with(test_data, {
   test_that("histogram plots histogram with just seq_data provided", {
     data_summary <- results_summary_data$results$summary["3-2", ]
     seq_data <- results_summary_data$results$files[[data_summary$Filename]]
-    output <- histogram(seq_data = seq_data,
-                       render = FALSE)
+    png(fp_devnull)
+    output <- histogram(seq_data = seq_data)
+    dev.off()
     output_expected <- within(list(), {
       orig <- data.frame(Length = as.integer(c(40, 41, 43, 46, 47, 48, 50, 162,
                                                166, 220, 224, 232, 234, 236,
@@ -59,8 +61,9 @@ with(test_data, {
   test_that("histogram works with empty seq_data", {
     data_summary <- results_summary_data$results$summary["3-2", ]
     seq_data <- results_summary_data$results$files[[data_summary$Filename]][0, ]
-    output <- histogram(seq_data = seq_data,
-                       render = FALSE)
+    png(fp_devnull)
+    output <- histogram(seq_data = seq_data)
+    dev.off()
     output_expected <- within(list(), {
       orig <- data.frame(Length = as.integer(NA), Count = as.integer(NA))[0, ]
     })
@@ -73,10 +76,11 @@ with(test_data, {
     data_summary <- results_summary_data$results$summary["3-2", ]
     seq_data <- results_summary_data$results$files[[data_summary$Filename]]
     sample_data <- results_summary_data$results$samples[["3-2"]][0, ]
+    png(fp_devnull)
     output <- histogram(seq_data = seq_data,
                        sample_data = sample_data,
-                       cutoff_fraction = 0.05,
-                       render = FALSE)
+                       cutoff_fraction = 0.05)
+    dev.off()
     # With sample_data data empty but still provided we should still have the
     # same structure of output, just with zero-row data frames in most of the
     # list entries.


### PR DESCRIPTION
Updates histogram rendering to only plot the available data, which will avoid spurious warnings.  Fixes #65.