### PR TITLE
Fix superfluous quotes in report HTML when rendered with newer pandoc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # chiimp dev
 
+ * Fixed superfluous quotes in report HTML file when rendered with newer pandoc
+   ([#69])
  * Fixed spurious warnings during histogram plotting due to missing data
    ([#66])
  * Added option for custom text in genotype summary tables for untested
@@ -8,6 +10,7 @@
    ([#63])
  * Fixed handling of extra pheatmap arguments in `plot_dist_mat` ([#62])
 
+[#69]: https://github.com/ShawHahnLab/chiimp/pull/69
 [#66]: https://github.com/ShawHahnLab/chiimp/pull/66
 [#64]: https://github.com/ShawHahnLab/chiimp/pull/64
 [#63]: https://github.com/ShawHahnLab/chiimp/pull/63

--- a/R/chiimp.R
+++ b/R/chiimp.R
@@ -337,8 +337,6 @@ save_data <- function(results, config) {
 #'
 #' @return list of \code{--metadata} argument strings
 format_pandoc_args <- function(metadata) {
-  metadata <- paste(names(metadata),
-                    lapply(metadata,
-                           function(s) paste0("\"", s, "\"")), sep = ":")
+  metadata <- paste(names(metadata), metadata, sep = ":")
   paste("--metadata=", metadata, sep = "")
 }


### PR DESCRIPTION
This changes the report rendering to remove superfluous quotes around the title/author/date fields when using pandoc >= 2.6.  Fixes #68.