### PR TITLE
Make installer commands obey site-wide configuration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # chiimp dev
 
+ * Made installer obey site-wide R configuration if present ([#72])
  * Fixed superfluous quotes in report HTML file when rendered with newer pandoc
    ([#69])
  * Fixed spurious warnings during histogram plotting due to missing data
@@ -10,6 +11,7 @@
    ([#63])
  * Fixed handling of extra pheatmap arguments in `plot_dist_mat` ([#62])
 
+[#72]: https://github.com/ShawHahnLab/chiimp/pull/72
 [#69]: https://github.com/ShawHahnLab/chiimp/pull/69
 [#66]: https://github.com/ShawHahnLab/chiimp/pull/66
 [#64]: https://github.com/ShawHahnLab/chiimp/pull/64

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -10,5 +10,5 @@ set -e
 rscript=$(which Rscript)
 pkgdir=$(readlink -f $(dirname $BASH_SOURCE))
 cd "$pkgdir"
-"$rscript" --vanilla "$pkgdir/tools/install.R"
+"$rscript" --no-save --no-restore "$pkgdir/tools/install.R"
 read -n 1 -s -p "Press any key to continue . . ."; echo # see "pause" in cmd.exe

--- a/install_mac.command
+++ b/install_mac.command
@@ -10,5 +10,5 @@ set -e
 rscript=$(which Rscript)
 pkgdir=$(dirname $BASH_SOURCE)
 cd "$pkgdir"
-"$rscript" --vanilla "$pkgdir/tools/install.R"
+"$rscript" --no-save --no-restore "$pkgdir/tools/install.R"
 read -n 1 -s -p "Press any key to continue . . ."; echo # see "pause" in cmd.exe

--- a/install_windows.cmd
+++ b/install_windows.cmd
@@ -17,5 +17,5 @@ set pkgdir=%~dp0
 
 REM  Run bulk of the install within R.
 cd %pkgdir%
-"%rscript%" --vanilla "%pkgdir%\tools\install.R"
+"%rscript%" --no-save --no-restore "%pkgdir%\tools\install.R"
 pause


### PR DESCRIPTION
This replaces Rscript argument `--vanilla` with `--no-save --no-restore` in the Linux/Mac/Windows install scripts so that R's site-wide configuration is respected during CHIIMP installation.  Fixes #71.