### PR TITLE
Allow custom row names in load_csv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # chiimp dev
 
+ * Made `load_csv` use custom row names if given ([#74])
  * Made installer obey site-wide R configuration if present ([#72])
  * Fixed superfluous quotes in report HTML file when rendered with newer pandoc
    ([#69])
@@ -11,6 +12,7 @@
    ([#63])
  * Fixed handling of extra pheatmap arguments in `plot_dist_mat` ([#62])
 
+[#74]: https://github.com/ShawHahnLab/chiimp/pull/74
 [#72]: https://github.com/ShawHahnLab/chiimp/pull/72
 [#69]: https://github.com/ShawHahnLab/chiimp/pull/69
 [#66]: https://github.com/ShawHahnLab/chiimp/pull/66

--- a/R/io.R
+++ b/R/io.R
@@ -50,7 +50,7 @@ load_config <- function(fp) {
 #'   \code{\link[utils]{write.table}}.
 #'
 #' @return data frame
-#' 
+#'
 #' @describeIn load_csv Load CSV
 #'
 #' @export
@@ -60,7 +60,9 @@ load_csv <- function(fp, ...) {
                             sep = ",",
                             stringsAsFactors = FALSE,
                             ...)
-  rownames(data) <- make_rownames(data)
+  if (! "row.names" %in% names(list(...))) {
+    rownames(data) <- make_rownames(data)
+  }
   data
 }
 

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -90,6 +90,22 @@ with(test_data, {
     expect_equal(data, data_expected)
   })
 
+  test_that("load_csv uses row names given", {
+    # If we give a row.names argument it should pass that on to read.table and
+    # shouldn't automatically generate row names
+    fp <- tempfile()
+    data_expected <- data.frame(
+      Vec1 = c("A", "D"),
+      Vec2 = c("B", "E"),
+      Vec3 = c("C", "F"),
+      stringsAsFactors = FALSE,
+      row.names = NULL)
+    cat("Vec1,Vec2,Vec3\nA,B,C\nD,E,F\n", file = fp)
+    data <- load_csv(fp, row.names = NULL)
+    file.remove(fp)
+    expect_equal(data, data_expected)
+  })
+
 
   test_that("save_csv saves CSV files", {
     fp <- tempfile()


### PR DESCRIPTION
Updates load_csv to respect a row names argument if given.  Fixes #70.