### PR TITLE
Automatically find pandoc at run-time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,9 @@ jobs:
           name: "Store Artifacts: 00install.out"
           path: chiimp.Rcheck/00install.out
       - run:
+          name: "Run find_pandoc script"
+          command: Rscript exec/find_pandoc.R
+      - run:
           name: "Run demo script"
           command: bash exec/demo.sh $PWD/demo-files
       - store_artifacts:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # chiimp dev
 
+ * Fixed pandoc error with newer RStudio versions (>= 2022.02) by finding
+   pandoc automatically ([#75])
  * Made `load_csv` use custom row names if given ([#74])
  * Made installer obey site-wide R configuration if present ([#72])
  * Fixed superfluous quotes in report HTML file when rendered with newer pandoc
@@ -12,6 +14,7 @@
    ([#63])
  * Fixed handling of extra pheatmap arguments in `plot_dist_mat` ([#62])
 
+[#75]: https://github.com/ShawHahnLab/chiimp/pull/75
 [#74]: https://github.com/ShawHahnLab/chiimp/pull/74
 [#72]: https://github.com/ShawHahnLab/chiimp/pull/72
 [#69]: https://github.com/ShawHahnLab/chiimp/pull/69

--- a/exec/chiimp.cmd
+++ b/exec/chiimp.cmd
@@ -24,10 +24,6 @@ REM  Also note that spaces are OK in the Rscript path but not the path to the
 REM  script; for some reason that makes space-handling for the whole command
 REM  fail.
 for /f "tokens=* usebackq" %%x in (`"%rdir%\Rscript" %dir%\find_pandoc.R`) do set RSTUDIO_PANDOC=%%x
-REM  Removing the trailing space on the end of the variable I can't figure out
-REM  how to avoid
-REM  https://stackoverflow.com/a/29504225
-set RSTUDIO_PANDOC=%RSTUDIO_PANDOC:~0,-1%
 
 if "%~1"=="" (
 	echo.To run CHIIMP, drag and drop a configuration file onto this icon.

--- a/exec/chiimp.cmd
+++ b/exec/chiimp.cmd
@@ -15,7 +15,15 @@ set rpath=%rpath: "%1"=%
 set rpath=%rpath:"=%
 set rdir=%rpath%\..\
 
-for /f "tokens=* usebackq" %%x in (`%rdir%\Rscript %dir%\find_pandoc.R`) do set RSTUDIO_PANDOC=%%x
+REM  Figure out path to pandoc.
+REM  Haven't bothered to figure out what combinations of options to for /f are
+REM  quite right between this command and the one for rpath above.  If anyone
+REM  reading this understands the insanity of Microsoft's syntax here please go
+REM  ahead and make a pull request to clean this up.
+REM  Also note that spaces are OK in the Rscript path but not the path to the
+REM  script; for some reason that makes space-handling for the whole command
+REM  fail.
+for /f "tokens=* usebackq" %%x in (`"%rdir%\Rscript" %dir%\find_pandoc.R`) do set RSTUDIO_PANDOC=%%x
 
 if "%~1"=="" (
 	echo.To run CHIIMP, drag and drop a configuration file onto this icon.

--- a/exec/chiimp.cmd
+++ b/exec/chiimp.cmd
@@ -24,6 +24,10 @@ REM  Also note that spaces are OK in the Rscript path but not the path to the
 REM  script; for some reason that makes space-handling for the whole command
 REM  fail.
 for /f "tokens=* usebackq" %%x in (`"%rdir%\Rscript" %dir%\find_pandoc.R`) do set RSTUDIO_PANDOC=%%x
+REM  Removing the trailing space on the end of the variable I can't figure out
+REM  how to avoid
+REM  https://stackoverflow.com/a/29504225
+set RSTUDIO_PANDOC=%RSTUDIO_PANDOC:~0,-1%
 
 if "%~1"=="" (
 	echo.To run CHIIMP, drag and drop a configuration file onto this icon.

--- a/exec/chiimp.cmd
+++ b/exec/chiimp.cmd
@@ -15,8 +15,7 @@ set rpath=%rpath: "%1"=%
 set rpath=%rpath:"=%
 set rdir=%rpath%\..\
 
-REM  TODO: detect RStudio instead of presuming the path
-set RSTUDIO_PANDOC=C:\Program Files\RStudio\bin\pandoc
+for /f "tokens=* usebackq" %%x in (`%rdir%\Rscript %dir%\find_pandoc.R`) do set RSTUDIO_PANDOC=%%x
 
 if "%~1"=="" (
 	echo.To run CHIIMP, drag and drop a configuration file onto this icon.

--- a/exec/chiimp.command
+++ b/exec/chiimp.command
@@ -18,11 +18,10 @@ if [[ $# -eq 0 ]]; then
 	echo "https://shawhahnlab.github.io/chiimp/GUIDE.pdf"
 	echo
 else
-	which pandoc > /dev/null || export RSTUDIO_PANDOC=/Applications/RStudio.app/Contents/MacOS/pandoc/
-
 	if [[ ! "$dir" =~ ^/ ]]; then
 		rel=$(pwd)
 	fi
+	export RSTUDIO_PANDOC=$(Rscript "$rel/$dir/find_pandoc.R")
 	cd "$cfg_dir"
 	Rscript "$rel/$dir/chiimp" "$@"
 fi

--- a/exec/chiimp.sh
+++ b/exec/chiimp.sh
@@ -16,7 +16,7 @@ if [[ $# -eq 0 ]]; then
 	echo "https://shawhahnlab.github.io/chiimp/GUIDE.pdf"
 	echo
 else
-	which pandoc > /dev/null || export RSTUDIO_PANDOC=/usr/lib/rstudio/bin/pandoc
+	export RSTUDIO_PANDOC=$(Rscript "$dir/find_pandoc.R")
 	cd "$cfg_dir"
 	Rscript "$dir/chiimp" $*
 fi

--- a/exec/find_pandoc.R
+++ b/exec/find_pandoc.R
@@ -46,4 +46,6 @@ find_pandoc <- function() {
   return(pandoc_dir)
 }
 
-cat(find_pandoc(), end = "\n")
+# Leaving off a newline for windows because chiimp.cmd mangles that to a space
+# and then keeps it on the end of the file path.
+cat(find_pandoc(), end = if (.Platform$OS.type == "windows") "" else "\n")

--- a/exec/find_pandoc.R
+++ b/exec/find_pandoc.R
@@ -23,13 +23,15 @@ find_pandoc <- function() {
     list.files("/Applications", pattern = "^RStudio.*.app", full.names = TRUE),
     "/usr/lib/rstudio")
 
-  execs <- file.path(strsplit(Sys.getenv("PATH"), ":")[[1]], "pandoc")
+  execs <- file.path(
+    strsplit(Sys.getenv("PATH"), .Platform$path.sep)[[1]],
+    c("pandoc", "pandoc.exe"))
   execs <- execs[file.exists(execs)]
 
   # Find files (no dirs) that are named exactly "pandoc", and get the full path
   # to the parent dir of any found
   pandoc_dirs_available <- c(
-    dirname(list.files(search_paths, recursive = TRUE, full.names = TRUE, pattern = "^pandoc$")),
+    dirname(list.files(search_paths, recursive = TRUE, full.names = TRUE, pattern = "^pandoc(?:\\.exe)$")),
     dirname(execs))
 
   # Let rmarkdown package decide which pandoc to use, if that feature is

--- a/exec/find_pandoc.R
+++ b/exec/find_pandoc.R
@@ -1,6 +1,7 @@
 #!/usr/bin/env Rscript
 
-# Figure out the path to the pandoc executable.  In order of priority:
+# Figure out the path to the pandoc executable's parent directory.  In order of
+# priority:
 #
 #  1. Anything set in RSTUDIO_PANDOC env variable
 #  2. Anything found in installed copies of RStudio
@@ -28,10 +29,10 @@ find_pandoc <- function() {
     c("pandoc", "pandoc.exe"))
   execs <- execs[file.exists(execs)]
 
-  # Find files (no dirs) that are named exactly "pandoc", and get the full path
-  # to the parent dir of any found
+  # Find files (no dirs) that are named exactly "pandoc" or "pandoc.exe", and
+  # get the full path to the parent dir of any found
   pandoc_dirs_available <- c(
-    dirname(list.files(search_paths, recursive = TRUE, full.names = TRUE, pattern = "^pandoc(?:\\.exe)$")),
+    dirname(list.files(search_paths, recursive = TRUE, full.names = TRUE, pattern = "^(pandoc|pandoc\\.exe)$")),
     dirname(execs))
 
   # Let rmarkdown package decide which pandoc to use, if that feature is
@@ -41,7 +42,7 @@ find_pandoc <- function() {
   pandoc_dir <- if ("find_pandoc" %in% getNamespaceExports("rmarkdown")) {
     rmarkdown::find_pandoc(dir = pandoc_dirs_available)$dir
   } else {
-    file.path(pandoc_dirs_available[1], "pandoc")
+    pandoc_dirs_available[1]
   }
   return(pandoc_dir)
 }

--- a/exec/find_pandoc.R
+++ b/exec/find_pandoc.R
@@ -47,4 +47,4 @@ find_pandoc <- function() {
   return(pandoc_dir)
 }
 
-cat(find_pandoc(), end = "\n")
+cat(find_pandoc(), "\n", sep = "")

--- a/exec/find_pandoc.R
+++ b/exec/find_pandoc.R
@@ -46,6 +46,4 @@ find_pandoc <- function() {
   return(pandoc_dir)
 }
 
-# Leaving off a newline for windows because chiimp.cmd mangles that to a space
-# and then keeps it on the end of the file path.
-cat(find_pandoc(), end = if (.Platform$OS.type == "windows") "" else "\n")
+cat(find_pandoc(), end = "\n")

--- a/exec/find_pandoc.R
+++ b/exec/find_pandoc.R
@@ -1,0 +1,47 @@
+#!/usr/bin/env Rscript
+
+# Figure out the path to the pandoc executable.  In order of priority:
+#
+#  1. Anything set in RSTUDIO_PANDOC env variable
+#  2. Anything found in installed copies of RStudio
+#  3. Any other pandoc found on PATH
+
+find_pandoc <- function() {
+  # If there's already an environment variable defined, we'll just give that.
+  pandoc_env <- Sys.getenv("RSTUDIO_PANDOC")
+  if (pandoc_env != "") {
+    return(pandoc_env)
+  }
+
+  # On Windows this should give something like "c:/", but an empty string
+  # everywhere else.
+  prefix <- sub("/.*$", "/", normalizePath(".", winslash = "/"))
+
+  # Search for RStudio installations
+  search_paths <- c(
+    list.files(list.files(prefix, pattern = "Program Files.*", full.names = TRUE), pattern = "RStudio.*", full.names = TRUE),
+    list.files("/Applications", pattern = "^RStudio.*.app", full.names = TRUE),
+    "/usr/lib/rstudio")
+
+  execs <- file.path(strsplit(Sys.getenv("PATH"), ":")[[1]], "pandoc")
+  execs <- execs[file.exists(execs)]
+
+  # Find files (no dirs) that are named exactly "pandoc", and get the full path
+  # to the parent dir of any found
+  pandoc_dirs_available <- c(
+    dirname(list.files(search_paths, recursive = TRUE, full.names = TRUE, pattern = "^pandoc$")),
+    dirname(execs))
+
+  # Let rmarkdown package decide which pandoc to use, if that feature is
+  # available (>=2.2).  It will also implicitly accept a pandoc executable found
+  # on the PATH.  If that function's not available we'll just pick a pandoc.
+  # https://stackoverflow.com/a/24692264
+  pandoc_dir <- if ("find_pandoc" %in% getNamespaceExports("rmarkdown")) {
+    rmarkdown::find_pandoc(dir = pandoc_dirs_available)$dir
+  } else {
+    file.path(pandoc_dirs_available[1], "pandoc")
+  }
+  return(pandoc_dir)
+}
+
+cat(find_pandoc(), end = "\n")


### PR DESCRIPTION
I previously hardcoded the RStudio-provided pandoc path in each OS's wrapper script, and as of RStudio 2022.02 the installed location changed.  This adds a helper script to automatically find pandoc from any RStudio installs or other common sources.  Fixes #73.