### PR TITLE
Fix row ordering in genotype summary tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: chiimp
 Title: Computational, High-throughput Individual Identification through Microsatellite Profiling
-Version: 0.3.1
+Version: 0.4.0
 Authors@R: person("Jesse", "Connell", email = "ancon@upenn.edu", role = c("aut", "cre"))
 Description: An R package to analyze microsatellites in high-throughput sequencing datasets.
 Depends: R (>= 3.2.3)

--- a/GUIDE.Rmd
+++ b/GUIDE.Rmd
@@ -4,11 +4,13 @@
 
 title: "CHIIMP User Guide"
 author: "Jesse Connell"
-date: "2019/07/10"
+date: "2022/04/25"
 output:
   pdf_document:
     toc: true
     toc_depth: 3
+urlcolor: blue
+linkcolor: blue
 ---
 
 ```{r setup, include=FALSE}
@@ -34,12 +36,12 @@ package documentation.
 
 ## Installation
 
-Most dependencies are provided by installation of [R] and [RStudio].  Once
-these are installed, follow the specific instructions below for your operating
-system.  In all three cases CHIIMP performs an anlysis when a configuration
-file is dragged and dropped onto the desktop icon; there is no interactive
-interface via the icon, though the R package can be used interactively.  See
-the Usage section for more information.
+First install [R] and [RStudio], which will supply most software dependencies
+for CHIIMP.  Once these are installed, follow the specific instructions below
+for your operating system.  In all three cases CHIIMP performs an analysis when
+a configuration file is dragged and dropped onto the desktop icon; there is no
+interactive interface via the icon, though the R package can be used
+interactively.  See the Usage section for more information.
 
 ### Windows
 
@@ -48,12 +50,12 @@ the package and R dependencies, and create a desktop shortcut.
 
 ### Mac OS
 
-On Mac OS, double-click the `install_mac.command` shell script to automatically
-install the package along with R dependencies and create a desktop alias.  If
-the install script won't open because of a security warning, you can
-right-click (control+click) and select "Open" in the menu that appears.
-Apple has specific instructions [here](https://support.apple.com/kb/PH25088?locale=en_US)
-about these security setings.
+On Mac OS, right-click (control+click) the `install_mac.command` shell script,
+select "Open," and also click "Open" in the window that appears to confirm that
+really do want to open it.  (Apple has specific instructions about these
+security precautions [here](https://support.apple.com/kb/PH25088?locale=en_US).)
+This will automatically install the package along with R dependencies and
+create a desktop alias.
 
 If a window appears recommending installation of the Mac OS command-line
 developer tools, go ahead and install them.  After that you'll probably need to
@@ -61,9 +63,12 @@ re-run the CHIIMP installer again to finish the install.
 
 ### Linux
 
-On Linux, run the `install_linux.sh` shell script to automatically install the 
-package along with R dependencies.  An icon for the program is created at 
-`$HOME/Desktop/CHIIMP`.
+On Linux, run the `install_linux.sh` shell script to automatically install the
+package along with R dependencies.  An icon for the program is created at
+`$HOME/Desktop/CHIIMP.desktop`.  Specific usage of the desktop icon will depend
+on the desktop environment in use.  (The `CHIIMP.desktop` text file references
+the installed chiimp executable, and supplies the config file as a command-line
+argument when dragged and dropped onto the icon.)
 
 ## Input Data Organization
 
@@ -94,24 +99,24 @@ primer sequence is one of the filtering criteria during analysis.)
 The description of the samples to be analyzed can be provided in a spreadsheet,
 or automatically loaded from the data file names.  An example spreadsheet:
 
-| Filename      | Replicate   | Sample | Locus |
-| -------------:| -----------:| ------:| -----:|
-| 100-1-A.fastq |     1       | 100    | A     |
-| 100-2-A.fastq |     2       | 100    | A     |
-| 100-1-B.fastq |     1       | 100    | B     |
-| 100-2-B.fastq |     2       | 100    | B     |
-| 100-1-1.fastq |     1       | 100    | 1     |
-| 100-2-1.fastq |     2       | 100    | 1     |
-| 100-1-2.fastq |     1       | 100    | 2     |
-| 100-2-2.fastq |     2       | 100    | 2     |
-| 101-1-A.fastq |     1       | 101    | A     |
-| 101-2-A.fastq |     2       | 101    | A     |
-| 101-1-B.fastq |     1       | 101    | B     |
-| 101-2-B.fastq |     2       | 101    | B     |
-| 101-1-1.fastq |     1       | 101    | 1     |
-| 101-2-1.fastq |     2       | 101    | 1     |
-| 101-1-2.fastq |     1       | 101    | 2     |
-| 101-2-2.fastq |     2       | 101    | 2     |
+| `Filename`         | `Replicate` | `Sample` | `Locus` |
+|:------------------:|:-----------:|:--------:|:-------:|
+| `100-1-A.fastq.gz` |    `1`      |   `100`  |    `A`  |
+| `100-2-A.fastq.gz` |    `2`      |   `100`  |    `A`  |
+| `100-1-B.fastq.gz` |    `1`      |   `100`  |    `B`  |
+| `100-2-B.fastq.gz` |    `2`      |   `100`  |    `B`  |
+| `100-1-1.fastq.gz` |    `1`      |   `100`  |    `1`  |
+| `100-2-1.fastq.gz` |    `2`      |   `100`  |    `1`  |
+| `100-1-2.fastq.gz` |    `1`      |   `100`  |    `2`  |
+| `100-2-2.fastq.gz` |    `2`      |   `100`  |    `2`  |
+| `101-1-A.fastq.gz` |    `1`      |   `101`  |    `A`  |
+| `101-2-A.fastq.gz` |    `2`      |   `101`  |    `A`  |
+| `101-1-B.fastq.gz` |    `1`      |   `101`  |    `B`  |
+| `101-2-B.fastq.gz` |    `2`      |   `101`  |    `B`  |
+| `101-1-1.fastq.gz` |    `1`      |   `101`  |    `1`  |
+| `101-2-1.fastq.gz` |    `2`      |   `101`  |    `1`  |
+| `101-1-2.fastq.gz` |    `1`      |   `101`  |    `2`  |
+| `101-2-2.fastq.gz` |    `2`      |   `101`  |    `2`  |
 
 These columns are required for each entry:
  
@@ -136,13 +141,12 @@ Usage section for more information.
 The description of the loci should be given in a spreadsheet with loci on rows
 and attributes on columns.  For example:
 
-```{r, echo=FALSE}
-# Show the example locus attributes table
-locus_attrs <- load_locus_attrs("inst/example_locus_attrs.csv")
-locus_attrs$Primer <- paste0(substr(locus_attrs$Primer, 1, 12), "...")
-locus_attrs$ReversePrimer <- paste0(substr(locus_attrs$ReversePrimer, 1, 12), "...")
-knitr::kable(locus_attrs, row.names = FALSE)
-```
+| `Locus` | `LengthMin` | `LengthMax` | `LengthBuffer` | `Motif` |    `Primer`       |  `ReversePrimer` |
+|:-------:| -----------:| -----------:| --------------:|:-------:|:-----------------:|:----------------:|
+|   `A`   |       `131` |      `179`  |          `20`  |  `TAGA` | `TATCACTGGTGT...` | `CACAGTTGTGTG...`|
+|   `B`   |       `194` |      `235`  |          `20`  |  `TAGA` | `AGTCTCTCTTTC...` | `TAGGAGCCTGTG...`|
+|   `1`   |       `232` |      `270`  |          `20`  |  `TATC` | `ACAGTCAAGAAT...` | `CTGTGGCTCAAA...`|
+|   `2`   |       `218` |      `337`  |          `20`  |  `TCCA` | `TTGTCTCCCCAG...` | `TCTGTCATAAAC...`|
 
 These columns are required:
  
@@ -157,7 +161,8 @@ These columns are required:
  * Primer: The forward PCR primer used in preparing the sequencing library. 
  This is used as one of the checks for candidate allele sequences.
  * ReversePrimer: The reverse PCR primer used in preparing the sequencing
- library.  This is not currently used.
+ library.  This is not currently used unless `use_reverse_primers` is enabled
+ in the configuration.
 
 ### Known Individuals (Optional)
 
@@ -165,16 +170,16 @@ If a spreadsheet of genotypes for known individuals is supplied, the analysis
 can attempt to match samples with the known genotypes automatically.  For
 example:
 
-| Name          | Locus       | Allele1Seq     | Allele2Seq     |
-|:-------------:|:-----------:|:--------------:|:--------------:|
-| CH001         |     A       | ATTATCACTGG... | ATTATCACTGG... |
-| CH001         |     B       | TCAGTCTCTCT... |                |
-| CH001         |     1       | AGACAGTCAAG... | AGACAGTCAAG... |
-| CH001         |     2       | CTTTGTCTCCC... | CTTTGTCTCCC... |
-| CH002         |     A       | ATTATCACTGG... | ATTATCACTGG... |
-| CH002         |     B       | TCAGTCTCTCT... | TCAGTCTCTCT... |
-| CH002         |     1       | AGACAGTCAAG... |                |
-| CH002         |     2       | CTTTGTCTCCC... | CTTTGTCTCCC... |
+|   `Name`  | `Locus` |   `Allele1Seq`   |   `Allele2Seq`   |
+|:---------:|:-------:|:----------------:|:----------------:|
+|  `CH001`  |   `A`   | `ATTATCACTGG...` | `ATTATCACTGG...` |
+|  `CH001`  |   `B`   | `TCAGTCTCTCT...` |                  |
+|  `CH001`  |   `1`   | `AGACAGTCAAG...` | `AGACAGTCAAG...` |
+|  `CH001`  |   `2`   | `CTTTGTCTCCC...` | `CTTTGTCTCCC...` |
+|  `CH002`  |   `A`   | `ATTATCACTGG...` | `ATTATCACTGG...` |
+|  `CH002`  |   `B`   | `TCAGTCTCTCT...` | `TCAGTCTCTCT...` |
+|  `CH002`  |   `1`   | `AGACAGTCAAG...` |                  |
+|  `CH002`  |   `2`   | `CTTTGTCTCCC...` | `CTTTGTCTCCC...` |
 
 The order of the alleles given is not important, and homozygous individuals may 
 have Allele2Seq either left blank or set to a copy of Allele1Seq.  The sequences
@@ -186,14 +191,14 @@ used for the PCR primers described above.
 If a spreadsheet of allele names and sequences is supplied, the analysis 
 will use those names in summary tables in the output report.  For example:
 
-| Locus |  Name       | Seq            |
-|:-----:|:-----------:|:--------------:|
-| A     | 200-a       | ATTATCACTGG... |
-| A     | 180-a       | ATTATCACTGG... |
-| A     | 180-b       | ATTATCACTGG... |
-| B     | 300-a       | ATTATCACTGG... |
-| B     | 305-a       | ATTATCACTGG... |
-| B     | 290-a       | ATTATCACTGG... |
+| `Locus` |   `Name`    |      `Seq`       |
+|:-------:|:-----------:|:----------------:|
+|   `A`   |   `200-a`   | `ATTATCACTGG...` |
+|   `A`   |   `180-a`   | `ATTATCACTGG...` |
+|   `A`   |   `180-b`   | `ATTATCACTGG...` |
+|   `B`   |   `300-a`   | `ATTATCACTGG...` |
+|   `B`   |   `305-a`   | `ATTATCACTGG...` |
+|   `B`   |   `290-a`   | `ATTATCACTGG...` |
 
 The software will automatically create short allele names for any identified 
 allele not listed in the allele spreadsheet (or for all alleles if no 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# chiimp dev
+# chiimp 0.4.0
 
  * Fixed pandoc error with newer RStudio versions (>= 2022.02) by finding
    pandoc automatically ([#75])

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # chiimp 0.4.0
 
+ * Fixed genotype summary table row ordering for certain edge cases ([#81])
  * Fixed pandoc error with newer RStudio versions (>= 2022.02) by finding
    pandoc automatically ([#75])
  * Made `load_csv` use custom row names if given ([#74])
@@ -14,6 +15,7 @@
    ([#63])
  * Fixed handling of extra pheatmap arguments in `plot_dist_mat` ([#62])
 
+[#81]: https://github.com/ShawHahnLab/chiimp/pull/81
 [#75]: https://github.com/ShawHahnLab/chiimp/pull/75
 [#74]: https://github.com/ShawHahnLab/chiimp/pull/74
 [#72]: https://github.com/ShawHahnLab/chiimp/pull/72

--- a/R/chiimp.R
+++ b/R/chiimp.R
@@ -131,6 +131,7 @@
 #'   "config."
 #'
 #' @examples
+#' \dontrun{
 #' # Set up a temporary copy of the CHIIMP test data
 #' example_dir <- tempfile()
 #' dir.create(example_dir)
@@ -145,6 +146,7 @@
 #' config_path <- system.file("example_config.yml", package = "chiimp")
 #' config <- load_config(config_path)
 #' results <- full_analysis(config)
+#' }
 #'
 #' @export
 full_analysis <- function(config, dataset=NULL) {
@@ -241,6 +243,7 @@ full_analysis <- function(config, dataset=NULL) {
 #'   "config."
 #'
 #' @examples
+#' \dontrun{
 #' # Set up a temporary copy of the CHIIMP test data
 #' example_dir <- tempfile()
 #' dir.create(example_dir)
@@ -254,6 +257,7 @@ full_analysis <- function(config, dataset=NULL) {
 #' # Run the example analysis
 #' config_path <- system.file("example_config.yml", package = "chiimp")
 #' results <- main(config_path)
+#' }
 #'
 #' @export
 main <- function(args=NULL) {

--- a/R/histogram.R
+++ b/R/histogram.R
@@ -135,10 +135,10 @@ str_hist_render <- function(bars, main, xlim, cutoff_fraction) {
     cutoff <- (cutoff_fraction * sum(bars$filt$Count))[1]
     if (! is.na(cutoff)) {
       categories["threshold", "Render"] <- TRUE
-      xlim_view <- par("usr")[1:2]
+      xlim_view <- graphics::par("usr")[1:2]
       xlim_view[1] <- floor(xlim_view[1])
       xlim_view[2] <- ceiling(xlim_view[2])
-      points(xlim_view[1]:xlim_view[2],
+      graphics::points(xlim_view[1]:xlim_view[2],
              rep(cutoff, diff(xlim_view) + 1), pch = ".")
     }
     # Draw domain of sample data
@@ -194,9 +194,9 @@ str_hist_setup_legend <- function(bars) {
 #' device?
 get_px_width <- function() {
   # https://stackoverflow.com/questions/17213293/how-to-get-r-plot-window-size
-  px_width_fig <- dev.size("px")[1] # width of whole figure in pixels
-  px_width_plt <- diff(par("plt")[1:2] * px_width_fig) # just the plot region
-  width_plt <- diff(par("usr")[1:2]) # width of plot region in plot units
+  px_width_fig <- grDevices::dev.size("px")[1] # width of whole figure in pixels
+  px_width_plt <- diff(graphics::par("plt")[1:2] * px_width_fig) # just the plot region
+  width_plt <- diff(graphics::par("usr")[1:2]) # width of plot region in plot units
   step_width <- px_width_plt / width_plt # pixels per plot unit increment
   step_width
 }

--- a/R/installer.R
+++ b/R/installer.R
@@ -165,7 +165,7 @@ install <- function(path_package) {
     cat("\n")
     cat("### Installing devtools\n")
     cat("\n")
-    install.packages("devtools", repos = "https://cloud.r-project.org")
+    utils::install.packages("devtools", repos = "https://cloud.r-project.org")
   }
 
   cat("\n")

--- a/R/report.R
+++ b/R/report.R
@@ -68,6 +68,10 @@ tabulate_allele_names <- function(data, extra_cols=NULL) {
                        c(1, 2),
                        sep = "_")
   colnames(tbl) <- c("ID", extra_cols, allele_cols)
+  # If extra columns were given, re-order output rows using those
+  if (! is.null(extra_cols)) {
+    tbl <- tbl[order_entries(tbl[, extra_cols]), ]
+  }
   tbl
 }
 

--- a/R/zz_helper_data.R
+++ b/R/zz_helper_data.R
@@ -31,9 +31,9 @@ test_data <- within(list(), {
   rng_orig <- RNGkind()
   if (length(rng_orig) > 2) {
     warn_orig <- options()$warn
-    options(warn=-1)
+    options(warn = -1)
     RNGkind("Mersenne-Twister", "Inversion", "Rounding")
-    options(warn=warn_orig)
+    options(warn = warn_orig)
     rm(warn_orig)
   }
   # Careful!  When running via a package check we might be in temporary

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ high-throughput sequencing datasets.
 
 For automated installation and program usage see [GUIDE.pdf] here or in a
 [released version](https://github.com/ShawHahnLab/chiimp/releases), and the [worked examples].
-The most recent released version is [0.3.1](https://github.com/ShawHahnLab/chiimp/releases/tag/0.3.1).
+The most recent released version is [0.4.0](https://github.com/ShawHahnLab/chiimp/releases/tag/0.4.0).
 For usage as an R package also see the built-in package documentation.  The
 package-level page (`?chiimp`) provides an overview with links to specific
 functions.

--- a/man/full_analysis.Rd
+++ b/man/full_analysis.Rd
@@ -22,6 +22,7 @@ Given a list of configuration options, run all aspects of a microsatellite
 analysis, and save the corresponding output files.
 }
 \examples{
+\dontrun{
 # Set up a temporary copy of the CHIIMP test data
 example_dir <- tempfile()
 dir.create(example_dir)
@@ -36,5 +37,6 @@ file.copy(locus_attrs_path, "locus_attrs.csv")
 config_path <- system.file("example_config.yml", package = "chiimp")
 config <- load_config(config_path)
 results <- full_analysis(config)
+}
 
 }

--- a/man/main.Rd
+++ b/man/main.Rd
@@ -20,6 +20,7 @@ arguments, load the configuration data (see \code{\link{load_config}}), and
 run \code{\link{full_analysis}}.
 }
 \examples{
+\dontrun{
 # Set up a temporary copy of the CHIIMP test data
 example_dir <- tempfile()
 dir.create(example_dir)
@@ -33,5 +34,6 @@ file.copy(locus_attrs_path, "locus_attrs.csv")
 # Run the example analysis
 config_path <- system.file("example_config.yml", package = "chiimp")
 results <- main(config_path)
+}
 
 }

--- a/man/report_genotypes.Rd
+++ b/man/report_genotypes.Rd
@@ -24,5 +24,7 @@ data frame showing summary of genotypes.
 Report the genotypes present in a processed dataset in a concise data frame.
 This will arrange the allele names into a wide-format table with unique
 samples on rows and loci on columns, do some automatic cleanup on the
-columns, and show closest-matching individuals per entry, if given.
+columns, and show closest-matching individuals per entry, if given.  All NA
+entries are replaced with blank strings or optionally (for NA Replicates or
+untested sample/locus combinations) other custom placeholder text.
 }

--- a/man/str_hist_render.Rd
+++ b/man/str_hist_render.Rd
@@ -7,7 +7,7 @@
 str_hist_render(bars, main, xlim, cutoff_fraction)
 }
 \arguments{
-\item{bars}{data frames of counts-vs-lengths as prepared by
+\item{bars}{list of data frames of counts-vs-lengths as prepared by
 \code{\link{str_hist_setup}}.}
 
 \item{main}{title of the plot.}

--- a/tests/testthat/test_report.R
+++ b/tests/testthat/test_report.R
@@ -165,6 +165,15 @@ with(test_data, {
     tbl <- tabulate_allele_names(
       results_summary[order_entries(results_summary), ])
     expect_equivalent(tbl, subset(tbl_known, select = -c(Sample, Replicate)))
+    # Giving extra columns enforces output sorting as expected
+    tbl <- tabulate_allele_names(
+      results_summary,
+      extra_cols = c("Sample", "Replicate"))
+    expect_equivalent(tbl, tbl_known[order_entries(tbl_known), ])
+    tbl <- tabulate_allele_names(
+      results_summary[order_entries(results_summary), ],
+      extra_cols = c("Sample", "Replicate"))
+    expect_equivalent(tbl, tbl_known[order_entries(tbl_known), ])
   })
 
 

--- a/tests/testthat/test_report.R
+++ b/tests/testthat/test_report.R
@@ -45,7 +45,7 @@ with(test_data, {
       fp_img <- tempfile()
       png(fp_img)
       annotations <- data.frame(
-        Attribute=LETTERS[seq_along(rownames(dist_mat))])
+        Attribute = LETTERS[seq_along(rownames(dist_mat))])
       rownames(annotations) <- rownames(dist_mat)
       plot_data <- plot_dist_mat(dist_mat, annotation_col = annotations)
       dev.off()

--- a/tools/prep_release.sh
+++ b/tools/prep_release.sh
@@ -32,7 +32,7 @@ echo "$SEP Running devtools::check()"
 R --slave --vanilla -e "$chiimp_check"
 
 echo "$SEP Rendering user guide"
-R --slave --vanilla -e "rmarkdown::render('GUIDE.Rmd', output_file = 'GUIDE.pdf', quiet = TRUE)"
+./tools/render_guide.sh
 
 # Create bundled ZIP and TGZ versions without hidden top level files (such as
 # the git and travis stuff) and with the GUIDE.pdf.

--- a/tools/render_guide.sh
+++ b/tools/render_guide.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+R --slave --vanilla -e "rmarkdown::render('GUIDE.Rmd', output_file = 'GUIDE.pdf', quiet = TRUE)"


### PR DESCRIPTION
Adds an optional extra step of sorting output rows in`tabulate_allele_names` if optional `extra_cols` argument is given.  Fixes #80.