### PR TITLE
Handle one, zero, or unrecognized extra columns in tabulate_allele_names

### DIFF
--- a/R/report.R
+++ b/R/report.R
@@ -39,6 +39,14 @@ normalize_alleles <- function(data) {
 #'
 #' @export
 tabulate_allele_names <- function(data, extra_cols=NULL) {
+  if (length(extra_cols)) {
+    badcols <- extra_cols[! extra_cols %in% colnames(data)]
+    if (length(badcols)) {
+      stop(
+        paste("undefined extra columns in tabulate_allele_names: ",
+              badcols, collapse = " "))
+    }
+  }
   # Order and replicate (for homozygous) the allele names
   nms <- normalize_alleles(data[, c("Allele1Name", "Allele2Name")])
   # Create unique (aside from Locus) identifiers for each entry
@@ -69,8 +77,8 @@ tabulate_allele_names <- function(data, extra_cols=NULL) {
                        sep = "_")
   colnames(tbl) <- c("ID", extra_cols, allele_cols)
   # If extra columns were given, re-order output rows using those
-  if (! is.null(extra_cols)) {
-    tbl <- tbl[order_entries(tbl[, extra_cols]), ]
+  if (length(extra_cols)) {
+    tbl <- tbl[order_entries(tbl[, extra_cols, drop = FALSE]), ]
   }
   tbl
 }

--- a/tests/testthat/test_report.R
+++ b/tests/testthat/test_report.R
@@ -95,10 +95,25 @@ with(test_data, {
                             Replicate = integer(3) * NA,
                             stringsAsFactors = FALSE)
     with(results_summary_data, {
+      # The basic case: sample and replicate columns
       tbl <- tabulate_allele_names(results$summary,
                                    extra_cols = c("Sample", "Replicate"))
-      tbl <- tbl[, 1:3]
-      expect_equivalent(tbl, tbl_known)
+      expect_true(all(c("Sample", "Replicate") %in% colnames(tbl)))
+      expect_equivalent(tbl[, 1:3], tbl_known)
+      # What about just one column name?  (We'd better be using drop=FALSE!)
+      tbl <- tabulate_allele_names(results$summary,
+                                   extra_cols = "Sample")
+      expect_true("Sample" %in% colnames(tbl))
+      expect_false("Replicate" %in% colnames(tbl))
+      expect_equivalent(tbl[, 1:2], tbl_known[, 1:2])
+      # Unknown column name
+      expect_error({
+        tabulate_allele_names(results$summary,
+                              extra_cols = "DoesNotExist")
+      }, "undefined extra columns")
+      # Empty column name vector -> same as not given
+      tbl <- tabulate_allele_names(results$summary, extra_cols = character())
+      expect_true(all(! c("Sample", "Replicate") %in% colnames(tbl)))
     })
   })
 


### PR DESCRIPTION
Makes `tabulate_allele_names` handle an extra column name vector with one, zero, or unrecognized column names.  The first case works as always intended, the second behaves as if the argument was not given, and the third throws an error with a clearer message.  Fixes #82 (bug introduced in #81).