### PR TITLE
Add filename field code to Linux desktop icon

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # chiimp 0.4.0
 
+ * Fixed desktop icon drag-and-drop for recent Linux distributions ([#85])
  * Fixed genotype summary table row ordering for certain edge cases ([#81])
  * Fixed pandoc error with newer RStudio versions (>= 2022.02) by finding
    pandoc automatically ([#75])
@@ -15,6 +16,7 @@
    ([#63])
  * Fixed handling of extra pheatmap arguments in `plot_dist_mat` ([#62])
 
+[#85]: https://github.com/ShawHahnLab/chiimp/pull/85
 [#81]: https://github.com/ShawHahnLab/chiimp/pull/81
 [#75]: https://github.com/ShawHahnLab/chiimp/pull/75
 [#74]: https://github.com/ShawHahnLab/chiimp/pull/74

--- a/R/installer.R
+++ b/R/installer.R
@@ -86,18 +86,20 @@ setup_icon_linux <- function() {
   desktop_path <- normalizePath("~/Desktop", mustWork = FALSE)
   icon_path <- NULL
   if (dir.exists(desktop_path)) {
+    # https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
     desktop_file <- paste(
       "[Desktop Entry]",
       "Type=Application",
       "Terminal=true",
       "Name=CHIIMP",
-      paste("Exec", chiimp_path, sep = "="),
+      paste0('Exec="', chiimp_path, '" "%f"'),
       sep = "\n")
     icon_path <- file.path(desktop_path, "CHIIMP.desktop")
     icon_path <- normalizePath(icon_path, mustWork = FALSE)
     cat(desktop_file, file = icon_path, end = "\n")
-    # TODO double-check if .desktop files actually need to be marked
-    # exectuable.  This may not be necessary.
+    # If the .desktop file is not marked executable I get a security warning
+    # under XFCE (and possibly with other desktop environments) though I don't
+    # see anything about this in the freedesktop.org specs.
     system2("chmod", args = c("+x", icon_path))
   }
   return(icon_path)


### PR DESCRIPTION
This updates the CHIIMP.desktop file for Linux to have an explicit filename placeholder as required by [the spec](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables).  Fixes #84.