### PR TITLE
Check config files for unrecognized keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,4 +80,4 @@ workflows:
       - build:
           matrix:
             parameters:
-              rversion: ["3.6.3", "4.2.1"]
+              rversion: ["3.6.3", "4.2.1", "4.2.2"]

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
 Remotes:
   github::sherrillmix/dnar,
   github::sherrillmix/dnaplotr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.0
 Suggests:
   testthat,
   roxygen2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# chiimp dev
+
+ * Made `load_config` warn about any unrecognized configuration file entries
+   ([#88])
+
+[#88]: https://github.com/ShawHahnLab/chiimp/pull/88
+
 # chiimp 0.4.0
 
  * Fixed desktop icon drag-and-drop for recent Linux distributions ([#85])

--- a/R/io.R
+++ b/R/io.R
@@ -67,7 +67,7 @@ load_config_get_unknown_entries <- function(config) {
     }
     obj
   }
-  remaining <- modifyList(config, blank(config.defaults))
+  remaining <- utils::modifyList(config, blank(config.defaults))
   trim <- function(obj) {
     for (nm in names(obj)) {
       obj[[nm]] <- trim(obj[[nm]])

--- a/man/load_config.Rd
+++ b/man/load_config.Rd
@@ -10,13 +10,17 @@ load_config(fp)
 \item{fp}{path to configuration file.}
 }
 \value{
-list of configuration options
+nested list of configuration options
 }
 \description{
 Load a YAML-formatted text file of configuration options for microsatellite
-analysis.  This is currently just a wrapper around
-\code{\link[yaml]{yaml.load}}.  The \code{\link{main}} function loads
-configuration options with this for use by \code{\link{full_analysis}}.
+analysis.  The \code{\link{main}} function loads configuration options with
+this for use by \code{\link{full_analysis}}.
+}
+\details{
+Whatever entries are present in the file will be returned, but names that
+don't match known names (see \code{\link{config.defaults}}) will be reported
+in a warning.
 }
 \examples{
 filename <- system.file("example_config.yml", package = "chiimp")

--- a/tests/testthat/data/io/config.yml
+++ b/tests/testthat/data/io/config.yml
@@ -1,0 +1,3 @@
+fp_dataset: "samples.csv"
+output:
+  fp_rds: "results.rds"

--- a/tests/testthat/data/io/config_unrecognized_key.yml
+++ b/tests/testthat/data/io/config_unrecognized_key.yml
@@ -1,0 +1,7 @@
+fp_dataset: "samples.csv"
+output:
+  fp_rds: "results.rds"
+unrecognized: 10
+dataset_analysis:
+  name_args:
+    unknown: 5

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -57,6 +57,22 @@ setup_dataset <- function(reps=1:3, samps=1:5,
 with(test_data, {
 
 
+
+# test load_config --------------------------------------------------------
+
+
+  test_that("load_config loads config YAML files", {
+    # this would have been the right way to handle test data all along:
+    # https://r-pkgs.org/testing-design.html#storing-test-data
+    config_path <- test_path("data", "io", "config.yml")
+    config <- load_config(config_path)
+    expect_equal(
+      config,
+      list(fp_dataset = "samples.csv", output = list(fp_rds = "results.rds"))
+    )
+  })
+
+
 # test load_csv/save_csv --------------------------------------------------
 
 

--- a/tests/testthat/test_io.R
+++ b/tests/testthat/test_io.R
@@ -72,6 +72,26 @@ with(test_data, {
     )
   })
 
+  test_that("load_config handles unexpected entries", {
+    config_path <- test_path("data", "io", "config_unrecognized_key.yml")
+    # it should warn about whatever config entries are unknown, but still load
+    # and return whatever's there
+    expect_warning(
+      config <- load_config(config_path),
+      paste(
+        "unrecognized config file entries:",
+        "  unrecognized",
+        "  dataset_analysis:name_args:unknown", sep = "\n"))
+    expect_equal(
+      config,
+      list(
+        fp_dataset = "samples.csv",
+        output = list(fp_rds = "results.rds"),
+        unrecognized = 10,
+        dataset_analysis = list(name_args = list(unknown = 5)))
+    )
+  })
+
 
 # test load_csv/save_csv --------------------------------------------------
 


### PR DESCRIPTION
Adds a check in `load_config` for any keys that are not present in `config.defaults`, and throws a warning about any unrecognized keys found.  This should help reduce confusion by catching typos or incorrectly-structured config files. Fixes #58.