### PR TITLE
Make warnings display as they occur when running chiimp script

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,13 @@
 # chiimp dev
 
+ * Made warnings encountered in the chiimp script display as they occur, rather
+   than at the end ([#91])
  * Made `load_dataset` warn about repeated Sample+Replicate+Locus entries
    across rows ([#90])
  * Made `load_config` warn about any unrecognized configuration file entries
    ([#88])
 
+[#91]: https://github.com/ShawHahnLab/chiimp/pull/91
 [#90]: https://github.com/ShawHahnLab/chiimp/pull/90
 [#88]: https://github.com/ShawHahnLab/chiimp/pull/88
 

--- a/exec/chiimp
+++ b/exec/chiimp
@@ -9,6 +9,10 @@
 # In Linux this should be executable directly.  To use in Windows see
 # chiimp.cmd.
 
+# when running as a standalone program, show warnings as they occur, not all at
+# the very end like R does by default.
+options(warn = 1)
+
 # If called from package source, load from that
 args <- commandArgs()
 f <- gsub("^--file=", "", args[grep("^--file=", args)])


### PR DESCRIPTION
Sets `options(warn = 1)` at the start of the chiimp script so that warning messages are shown as they occur rather than as the script ends.  Fixes #89.